### PR TITLE
[ADD/#20] ENUM 클래스 추가

### DIFF
--- a/core/common/src/main/java/com/napzak/market/common/type/RoleType.kt
+++ b/core/common/src/main/java/com/napzak/market/common/type/RoleType.kt
@@ -1,0 +1,17 @@
+package com.napzak.market.common.type
+
+enum class RoleType(
+    val label: String,
+) {
+    STORE("상정"),
+    ONBOARDING("온보딩"),
+    REPORTED("신고 계정");
+
+    companion object {
+        fun get(name: String): RoleType = try {
+            RoleType.valueOf(name.uppercase())
+        } catch (e: IllegalArgumentException) {
+            STORE
+        }
+    }
+}

--- a/core/common/src/main/java/com/napzak/market/common/type/TradeStatusType.kt
+++ b/core/common/src/main/java/com/napzak/market/common/type/TradeStatusType.kt
@@ -3,16 +3,23 @@ package com.napzak.market.common.type
 enum class TradeStatusType(
     val label: String,
 ) {
-    OnSale(
-        label = ""
-    ),
-    Sold(
-        label = "판매 완료"
-    ),
-    Bought(
-        label = "구매 완료"
-    ),
-    Reserved(
-        label = "예약중"
-    ),
+    BEFORE_TRADE(label = ""),
+    COMPLETED_SELL(label = "판매 완료"),
+    COMPLETED_BUY(label = "구매 완료"),
+    RESERVED(label = "예약중");
+
+    companion object {
+        fun get(name: String, tradeType: TradeType): TradeStatusType {
+            return try {
+                val upperCaseName = name.uppercase()
+                when {
+                    upperCaseName == "COMPLETED" && tradeType == TradeType.SELL -> COMPLETED_SELL
+                    upperCaseName == "COMPLETED" && tradeType == TradeType.BUY -> COMPLETED_BUY
+                    else -> valueOf(upperCaseName)
+                }
+            } catch (e: Exception) {
+                BEFORE_TRADE
+            }
+        }
+    }
 }

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakLargeProductItem.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakLargeProductItem.kt
@@ -40,11 +40,11 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.napzak.market.common.type.TradeStatusType
 import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.R.drawable.ic_heart_filled_14
+import com.napzak.market.designsystem.R.drawable.ic_heart_unfilled_16
 import com.napzak.market.designsystem.R.drawable.ic_product_buy_complete
 import com.napzak.market.designsystem.R.drawable.ic_product_reservation
 import com.napzak.market.designsystem.R.drawable.ic_product_sell_complete
-import com.napzak.market.designsystem.R.drawable.ic_heart_filled_14
-import com.napzak.market.designsystem.R.drawable.ic_heart_unfilled_16
 import com.napzak.market.designsystem.R.string.production_item_buy
 import com.napzak.market.designsystem.R.string.production_item_price
 import com.napzak.market.designsystem.R.string.production_item_price_suggestion
@@ -228,11 +228,11 @@ private fun TradeStatusImage(
     shape: RoundedCornerShape,
     modifier: Modifier = Modifier,
 ) {
-    if (tradeStatus != TradeStatusType.OnSale) {
+    if (tradeStatus != TradeStatusType.BEFORE_TRADE) {
         val image = when(tradeStatus) {
-            TradeStatusType.Reserved -> ic_product_reservation
-            TradeStatusType.Sold -> ic_product_sell_complete
-            TradeStatusType.Bought -> ic_product_buy_complete
+            TradeStatusType.RESERVED -> ic_product_reservation
+            TradeStatusType.COMPLETED_SELL -> ic_product_sell_complete
+            TradeStatusType.COMPLETED_BUY -> ic_product_buy_complete
             else -> null
         }
 
@@ -392,7 +392,7 @@ private fun LargeProductItemPreview() {
                     isMyItem = false,
                     isSellElseBuy = true,
                     isSuggestionAllowed = false,
-                    tradeStatus = TradeStatusType.OnSale,
+                    tradeStatus = TradeStatusType.BEFORE_TRADE,
                     onLikeClick = { isLiked1 = !isLiked1 },
                     modifier = Modifier.weight(1f),
                 )
@@ -409,7 +409,7 @@ private fun LargeProductItemPreview() {
                     isMyItem = false,
                     isSellElseBuy = false,
                     isSuggestionAllowed = true,
-                    tradeStatus = TradeStatusType.Sold,
+                    tradeStatus = TradeStatusType.COMPLETED_SELL,
                     onLikeClick = { isLiked2 = !isLiked2 },
                     modifier = Modifier.weight(1f),
                 )
@@ -433,7 +433,7 @@ private fun LargeProductItemPreview() {
                     isMyItem = false,
                     isSellElseBuy = false,
                     isSuggestionAllowed = false,
-                    tradeStatus = TradeStatusType.Sold,
+                    tradeStatus = TradeStatusType.COMPLETED_SELL,
                     onLikeClick = { isLiked1 = !isLiked1 },
                     modifier = Modifier.weight(1f),
                 )
@@ -450,7 +450,7 @@ private fun LargeProductItemPreview() {
                     isMyItem = false,
                     isSellElseBuy = false,
                     isSuggestionAllowed = true,
-                    tradeStatus = TradeStatusType.Reserved,
+                    tradeStatus = TradeStatusType.RESERVED,
                     onLikeClick = { isLiked2 = !isLiked2 },
                     modifier = Modifier.weight(1f),
                 )


### PR DESCRIPTION
## Related issue 🛠
- closed #20 

## Work Description ✏️
- UI에서 사용하는 Enum의 이름을 서버 API와 맞추는 작업을 진행했습니다.
- 새로 추가된 서버 Enum들도 추가했습니다.

## To Reviewers 📢
- 서버 API에서 받는 Enum과 UI에서 사용되는 Enum 간 이름을 통일할 필요가 있어서 급하게 수정했어요.
- 추가적으로 새로 추가된 상점 정보에 대한 Enum도 추가했습니다.
- 이번 PR을 기준으로 서버 API 명세서에 올라온 Enum 중 배너 관련 Enum 빼고 다 추가했습니다.
   - 배너 Enum의 경우, 홈에서만 사용되기 때문에 홈화면에서 따로 처리하도록 할게요~