### PR TITLE
[UI/#9] 공통 컴포넌트 구현(Button)

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -52,8 +51,11 @@ fun NapzakButton(
     Button(
         onClick = onClick,
         enabled = enabled,
-        modifier = modifier
-            .height(50.dp),
+        modifier = Modifier
+            .padding(
+                vertical = 14.dp,
+                horizontal = 10.dp,
+            ),
         colors = ButtonDefaults.buttonColors(
             containerColor = backgroundColor,
             contentColor = contentColor,

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -1,0 +1,113 @@
+package com.napzak.market.designsystem.component.button
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
+/**
+ * 공통 기본 버튼 컴포넌트입니다.
+ * 활성/비활성 상태** 두 가지 스타일을 기본 제공하며
+ * 버튼 내부에 **텍스트만** 또는 **텍스트 + 아이콘** 조합으로 사용할 수 있습니다.
+ * 납작 primary color가 적용되는 모든 버튼에서 사용 가능합니다.
+ *
+ * @param text 버튼에 표시될 텍스트
+ * @param onClick 버튼 클릭 시 실행할 로직
+ * @param enabled 버튼 활성화 여부 (기본값: true)
+ * @param icon 텍스트 오른쪽에 표시할 아이콘 (Painter 형식, 기본값: null)
+ * @param modifier 외부에서 버튼 크기나 위치 등을 조절할 수 있는 Modifier (기본값: Modifier)
+ */
+
+@Composable
+fun NapzakButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: Painter? = null,
+) {
+    val backgroundColor =
+        if (enabled) NapzakMarketTheme.colors.purple500 else NapzakMarketTheme.colors.gray100
+    val contentColor = NapzakMarketTheme.colors.white
+
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .height(50.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = backgroundColor,
+            contentColor = contentColor,
+        ),
+        shape = RoundedCornerShape(14.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = text,
+                style = NapzakMarketTheme.typography.body14b,
+                color = contentColor,
+            )
+            if (icon != null) {
+                Image(
+                    painter = icon,
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(contentColor),
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NapzakButtonPreview() {
+    NapzakMarketTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .width(360.dp)
+        ) {
+            NapzakButton(
+                text = "다음으로",
+                onClick = {},
+                icon = painterResource(id = R.drawable.ic_arrow_right),
+                enabled = true,
+                modifier = Modifier
+                    .fillMaxWidth(),
+            )
+
+            NapzakButton(
+                text = "다음으로",
+                onClick = {},
+                icon = painterResource(id = R.drawable.ic_arrow_right),
+                enabled = false,
+                modifier = Modifier
+                    .fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -83,7 +83,7 @@ fun NapzakButton(
 
 @Preview(showBackground = true)
 @Composable
-fun NapzakButtonPreview() {
+private fun NapzakButtonPreview() {
     NapzakMarketTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -52,11 +52,7 @@ fun NapzakButton(
         onClick = onClick,
         enabled = enabled,
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                vertical = 14.dp,
-                horizontal = 10.dp,
-            ),
+            .fillMaxWidth(),
         colors = ButtonDefaults.buttonColors(
             containerColor = backgroundColor,
             contentColor = contentColor,
@@ -71,6 +67,8 @@ fun NapzakButton(
                 text = text,
                 style = NapzakMarketTheme.typography.body14b,
                 color = contentColor,
+                modifier = Modifier
+                    .padding(vertical = 8.dp),
             )
             if (icon != null) {
                 Icon(

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -52,6 +52,7 @@ fun NapzakButton(
         onClick = onClick,
         enabled = enabled,
         modifier = Modifier
+            .fillMaxWidth()
             .padding(
                 vertical = 14.dp,
                 horizontal = 10.dp,
@@ -90,7 +91,6 @@ private fun NapzakButtonPreview() {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .padding(20.dp)
                 .width(360.dp)
         ) {
             NapzakButton(

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakButton.kt
@@ -1,6 +1,5 @@
 package com.napzak.market.designsystem.component.button
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,13 +11,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R
@@ -33,7 +33,7 @@ import com.napzak.market.designsystem.theme.NapzakMarketTheme
  * @param text 버튼에 표시될 텍스트
  * @param onClick 버튼 클릭 시 실행할 로직
  * @param enabled 버튼 활성화 여부 (기본값: true)
- * @param icon 텍스트 오른쪽에 표시할 아이콘 (Painter 형식, 기본값: null)
+ * @param icon 텍스트 오른쪽에 표시할 아이콘 (기본값: null)
  * @param modifier 외부에서 버튼 크기나 위치 등을 조절할 수 있는 Modifier (기본값: Modifier)
  */
 
@@ -43,7 +43,7 @@ fun NapzakButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    icon: Painter? = null,
+    icon: ImageVector? = null,
 ) {
     val backgroundColor =
         if (enabled) NapzakMarketTheme.colors.purple500 else NapzakMarketTheme.colors.gray100
@@ -70,10 +70,10 @@ fun NapzakButton(
                 color = contentColor,
             )
             if (icon != null) {
-                Image(
-                    painter = icon,
+                Icon(
+                    imageVector = icon,
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(contentColor),
+                    tint = Color.Unspecified,
                     modifier = Modifier.size(12.dp),
                 )
             }
@@ -94,7 +94,7 @@ fun NapzakButtonPreview() {
             NapzakButton(
                 text = "다음으로",
                 onClick = {},
-                icon = painterResource(id = R.drawable.ic_arrow_right),
+                icon = ImageVector.vectorResource(id = R.drawable.ic_arrow_right),
                 enabled = true,
                 modifier = Modifier
                     .fillMaxWidth(),
@@ -103,7 +103,7 @@ fun NapzakButtonPreview() {
             NapzakButton(
                 text = "다음으로",
                 onClick = {},
-                icon = painterResource(id = R.drawable.ic_arrow_right),
+                icon = ImageVector.vectorResource(id = R.drawable.ic_arrow_right),
                 enabled = false,
                 modifier = Modifier
                     .fillMaxWidth(),

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -1,0 +1,107 @@
+package com.napzak.market.designsystem.component.button
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
+/**
+ * 공통 체크 버튼 컴포넌트입니다.
+ *
+ * 체크 여부에 따라 서로 다른 아이콘이 표시되며 체크박스와 함께 텍스트가 수평으로 배치됩니다.
+ * 납작 마켓 내 약관 동의, 항목 선택 등 사용자 입력이 필요한 다양한 영역에서 재사용 가능합니다.
+ *
+ * @param checked 체크 상태 (true일 경우 체크된 아이콘 표시)
+ * @param text 체크박스 오른쪽에 표시될 텍스트
+ * @param modifier Modifier를 통해 외부에서 레이아웃 및 스타일을 조절할 수 있습니다 (기본값: Modifier)
+ * @param backgroundColor 컴포넌트 배경색 (기본값: NapzakMarketTheme.colors.white)
+ * @param onCheckedChange 체크 상태가 변경될 때 호출되는 콜백
+ */
+
+@Composable
+fun NapzakCheckedButton(
+    checked: Boolean,
+    text: String,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = NapzakMarketTheme.colors.white,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val checkIcon = if (checked) {
+        painterResource(id = R.drawable.ic_checked_box)
+    } else {
+        painterResource(id = R.drawable.ic_unchecked_box)
+    }
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .height(50.dp),
+        shape = RoundedCornerShape(14.dp),
+        color = backgroundColor,
+
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(start = 10.dp),
+        ) {
+            Image(
+                painter = checkIcon,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable { onCheckedChange(!checked) },
+            )
+            Text(
+                text = text,
+                style = NapzakMarketTheme.typography.body14b,
+                color = NapzakMarketTheme.colors.gray400,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NapzakCheckItemPreview() {
+    NapzakMarketTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .width(360.dp),
+        ) {
+            NapzakCheckedButton(
+                checked = true,
+                text = "약관 전체 동의",
+                onCheckedChange = {},
+                backgroundColor = NapzakMarketTheme.colors.white,
+            )
+
+            NapzakCheckedButton(
+                checked = false,
+                text = "배송비",
+                onCheckedChange = {},
+                backgroundColor = NapzakMarketTheme.colors.gray50,
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -69,7 +69,11 @@ fun NapzakCheckedButton(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(start = 10.dp),
+            modifier = Modifier
+                .padding(
+                    vertical = 14.dp,
+                    horizontal = 10.dp,
+                ),
         ) {
             Icon(
                 imageVector = checkIcon,

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -1,23 +1,25 @@
 package com.napzak.market.designsystem.component.button
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R
@@ -34,6 +36,7 @@ import com.napzak.market.designsystem.theme.NapzakMarketTheme
  * @param modifier Modifier를 통해 외부에서 레이아웃 및 스타일을 조절할 수 있습니다 (기본값: Modifier)
  * @param backgroundColor 컴포넌트 배경색 (기본값: NapzakMarketTheme.colors.white)
  * @param onCheckedChange 체크 상태가 변경될 때 호출되는 콜백
+ * @param icon 텍스트 가장 오른쪽에 표시할 아이콘 (기본값: null)
  */
 
 @Composable
@@ -43,11 +46,12 @@ fun NapzakCheckedButton(
     modifier: Modifier = Modifier,
     backgroundColor: Color = NapzakMarketTheme.colors.white,
     onCheckedChange: (Boolean) -> Unit,
+    icon: ImageVector? = null,
 ) {
     val checkIcon = if (checked) {
-        painterResource(id = R.drawable.ic_checked_box)
+        ImageVector.vectorResource(R.drawable.ic_checked_box)
     } else {
-        painterResource(id = R.drawable.ic_unchecked_box)
+        ImageVector.vectorResource(R.drawable.ic_unchecked_box)
     }
 
     Surface(
@@ -64,18 +68,30 @@ fun NapzakCheckedButton(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(start = 10.dp),
         ) {
-            Image(
-                painter = checkIcon,
+            Icon(
+                imageVector = checkIcon,
                 contentDescription = null,
                 modifier = Modifier
                     .size(24.dp)
                     .clickable { onCheckedChange(!checked) },
+                tint = Color.Unspecified,
             )
             Text(
                 text = text,
                 style = NapzakMarketTheme.typography.body14b,
                 color = NapzakMarketTheme.colors.gray400,
             )
+            Spacer(modifier = Modifier.weight(1f))
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                    modifier = Modifier
+                        .padding(end = 10.dp)
+                        .size(12.dp),
+                )
+            }
         }
     }
 }
@@ -92,6 +108,7 @@ fun NapzakCheckItemPreview() {
             NapzakCheckedButton(
                 checked = true,
                 text = "약관 전체 동의",
+                icon = ImageVector.vectorResource(id = R.drawable.ic_arrow_right),
                 onCheckedChange = {},
                 backgroundColor = NapzakMarketTheme.colors.white,
             )
@@ -99,6 +116,7 @@ fun NapzakCheckItemPreview() {
             NapzakCheckedButton(
                 checked = false,
                 text = "배송비",
+                icon = null,
                 onCheckedChange = {},
                 backgroundColor = NapzakMarketTheme.colors.gray50,
             )

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -60,8 +59,7 @@ fun NapzakCheckedButton(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp)
-            .height(50.dp),
+            .padding(horizontal = 20.dp),
         shape = RoundedCornerShape(14.dp),
         color = backgroundColor,
 
@@ -70,10 +68,7 @@ fun NapzakCheckedButton(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
-                .padding(
-                    vertical = 14.dp,
-                    horizontal = 10.dp,
-                ),
+                .padding(start = 10.dp),
         ) {
             Icon(
                 imageVector = checkIcon,
@@ -87,6 +82,8 @@ fun NapzakCheckedButton(
                 text = text,
                 style = NapzakMarketTheme.typography.body14b,
                 color = NapzakMarketTheme.colors.gray400,
+                modifier = Modifier
+                    .padding(vertical = 14.dp),
             )
             Spacer(modifier = Modifier.weight(1f))
             if (icon != null) {

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -101,7 +101,7 @@ fun NapzakCheckedButton(
 
 @Preview(showBackground = true)
 @Composable
-fun NapzakCheckItemPreview() {
+private fun NapzakCheckItemPreview() {
     NapzakMarketTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakCheckedButton.kt
@@ -23,7 +23,10 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.R.drawable.ic_checked_box
+import com.napzak.market.designsystem.R.drawable.ic_unchecked_box
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
 
 /**
  * 공통 체크 버튼 컴포넌트입니다.
@@ -49,9 +52,9 @@ fun NapzakCheckedButton(
     icon: ImageVector? = null,
 ) {
     val checkIcon = if (checked) {
-        ImageVector.vectorResource(R.drawable.ic_checked_box)
+        ImageVector.vectorResource(ic_checked_box)
     } else {
-        ImageVector.vectorResource(R.drawable.ic_unchecked_box)
+        ImageVector.vectorResource(ic_unchecked_box)
     }
 
     Surface(

--- a/core/designsystem/src/main/res/drawable/ic_arrow_right.xml
+++ b/core/designsystem/src/main/res/drawable/ic_arrow_right.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="12dp"
+    android:viewportWidth="8"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M1.441,10.588L1.441,10.588A0.76,0.76 0,0 1,1.441 9.513L5.483,5.471A0.76,0.76 90,0 1,6.558 5.471L6.558,5.471A0.76,0.76 90,0 1,6.558 6.546L2.516,10.588A0.76,0.76 90,0 1,1.441 10.588z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M1.441,1.412L1.441,1.412A0.76,0.76 90,0 1,2.516 1.412L6.559,5.455A0.76,0.76 90,0 1,6.559 6.53L6.559,6.53A0.76,0.76 90,0 1,5.484 6.53L1.441,2.487A0.76,0.76 90,0 1,1.441 1.412z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_checked_box.xml
+++ b/core/designsystem/src/main/res/drawable/ic_checked_box.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,0L18,0A6,6 0,0 1,24 6L24,18A6,6 0,0 1,18 24L6,24A6,6 0,0 1,0 18L0,6A6,6 0,0 1,6 0z"
+      android:fillColor="#7534FF"/>
+  <path
+      android:pathData="M7.422,10.858L7.422,10.858A1,1 0,0 1,8.836 10.858L11.705,13.727A1,1 81.785,0 1,11.705 15.142L11.705,15.142A1,1 81.785,0 1,10.291 15.142L7.422,12.273A1,1 0,0 1,7.422 10.858z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M16.578,8.858L16.578,8.858A1,1 102.008,0 1,16.578 10.273L11.709,15.142A1,1 93.185,0 1,10.295 15.142L10.295,15.142A1,1 93.185,0 1,10.295 13.727L15.164,8.858A1,1 102.008,0 1,16.578 8.858z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_unchecked_box.xml
+++ b/core/designsystem/src/main/res/drawable/ic_unchecked_box.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,0L18,0A6,6 0,0 1,24 6L24,18A6,6 0,0 1,18 24L6,24A6,6 0,0 1,0 18L0,6A6,6 0,0 1,6 0z"
+      android:fillColor="#D9D9D9"/>
+  <path
+      android:pathData="M7.422,10.858L7.422,10.858A1,1 0,0 1,8.836 10.858L11.705,13.727A1,1 81.785,0 1,11.705 15.142L11.705,15.142A1,1 81.785,0 1,10.291 15.142L7.422,12.273A1,1 0,0 1,7.422 10.858z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M16.578,8.858L16.578,8.858A1,1 102.008,0 1,16.578 10.273L11.709,15.142A1,1 93.185,0 1,10.295 15.142L10.295,15.142A1,1 93.185,0 1,10.295 13.727L15.164,8.858A1,1 102.008,0 1,16.578 8.858z"
+      android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description ✏️
- primary 버튼 컴포넌트
- 체크 버튼 컴포넌트

## Screenshot 📸
<img width="321" alt="스크린샷 2025-04-07 오후 3 12 13" src="https://github.com/user-attachments/assets/783abdc5-13f8-471c-bd83-bf93746ac44f" />
[primary 버튼 컴포넌트]

<img width="626" alt="스크린샷 2025-04-07 오후 3 11 46" src="https://github.com/user-attachments/assets/c0e49399-2af4-437f-a640-c9ebe5956fac" />
[체크 버튼 컴포넌트]

## Uncompleted Tasks 😅


## To Reviewers 📢
[primary 버튼 컴포넌트]
납작마켓 primary 컬러가 들어간 모든 버튼에서 사용가능합니다! 채팅하기, 탈퇴하기 버튼 등에서는 크기가 달라서 사용이 어렵습니다!~

[체크 버튼 컴포넌트]
온보딩 약관동의, 상품등록 등에서 사용되는 체크 아이콘이 들어간 컴포넌트 입니다! 해당 컴포넌트는 고정크기로만 사용되는 것 같아서 컴포넌트 자체에 패딩값을 넣어놨으니 크기 조절 없이 그냥 사용하시면 됩니다!

너무 늦게 올려서 죄송하구염 ㅜㅜㅜ 다른 작업들은 얼른 진행하도록하겠습니다!!