### PR TITLE
[UI/#46] 다이얼로그 컴포넌트 구현

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
@@ -1,0 +1,208 @@
+package com.napzak.market.designsystem.component.dialog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.napzak.market.designsystem.R.string.dialog_text_confirm
+import com.napzak.market.designsystem.R.string.dialog_text_dismiss
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
+/**
+ * 납작마켓 다이얼로그 컴포넌트입니다.
+ *
+ * onDismissRequest와 onDismissClick의 이벤트가 "같은 경우" 이 컴포넌트를 사용합니다.
+ */
+@Composable
+fun NapzakDialog(
+    title: String,
+    onConfirmClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    subTitle: String? = null,
+    confirmText: String = stringResource(dialog_text_confirm),
+    dismissText: String = stringResource(dialog_text_dismiss),
+    dialogColor: NapzakDialogColor = NapzakDialogDefault.color,
+) {
+    NapzakDialog(
+        title = title,
+        onConfirmClick = onConfirmClick,
+        onDismissClick = onDismissClick,
+        onDismissRequest = onDismissClick,
+        subTitle = subTitle,
+        confirmText = confirmText,
+        dismissText = dismissText,
+        dialogColor = dialogColor,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 납작마켓 다이얼로그 컴포넌트입니다.
+ *
+ * onDismissRequest와 onDismissClick의 이벤트가 "다른 경우" 이 컴포넌트를 사용합니다.
+ */
+@Composable
+fun NapzakDialog(
+    title: String,
+    onConfirmClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    subTitle: String? = null,
+    confirmText: String = stringResource(dialog_text_confirm),
+    dismissText: String = stringResource(dialog_text_dismiss),
+    dialogColor: NapzakDialogColor = NapzakDialogDefault.color,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .padding(horizontal = 30.dp)
+                .background(
+                    color = dialogColor.containerColor,
+                    shape = RoundedCornerShape(14.dp)
+                ),
+        ) {
+
+            Spacer(Modifier.height(38.dp))
+            Text(
+                text = title,
+                style = NapzakMarketTheme.typography.title18b.copy(
+                    color = dialogColor.titleColor,
+                ),
+            )
+            Spacer(Modifier.height(6.dp))
+            if (subTitle != null) {
+                Text(
+                    text = subTitle,
+                    style = NapzakMarketTheme.typography.caption12sb.copy(
+                        color = dialogColor.subTitleColor
+                    ),
+                )
+                Spacer(Modifier.height(24.dp))
+            } else {
+                Spacer(Modifier.height(38.dp))
+            }
+            DialogButtons(
+                confirmText = confirmText,
+                dismissText = dismissText,
+                dialogColor = dialogColor,
+                onConfirmClick = onConfirmClick,
+                onDismissClick = onDismissClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DialogButtons(
+    confirmText: String,
+    dismissText: String,
+    onConfirmClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    dialogColor: NapzakDialogColor,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .drawBehind {
+                drawLine(
+                    color = dialogColor.lineColor,
+                    start = Offset(0f, 0f),
+                    end = Offset(size.width, 0f),
+                    strokeWidth = Dp.Hairline.toPx()
+                )
+                drawLine(
+                    color = dialogColor.lineColor,
+                    start = Offset(size.width / 2, 0f),
+                    end = Offset(size.width / 2, size.height),
+                    strokeWidth = Dp.Hairline.toPx()
+                )
+            }) {
+        DialogButton(
+            text = confirmText,
+            textColor = dialogColor.confirmColor,
+            onClick = onConfirmClick,
+            modifier = Modifier.weight(1f),
+        )
+        DialogButton(
+            text = dismissText,
+            textColor = dialogColor.dismissColor,
+            onClick = onDismissClick,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun DialogButton(
+    text: String,
+    textColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .clickable(onClick = onClick),
+    ) {
+        Text(
+            text = text,
+            style = NapzakMarketTheme.typography.body14sb.copy(
+                color = textColor,
+            ),
+            modifier = Modifier.padding(vertical = 18.dp),
+        )
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun DeleteDialogPreview() {
+    NapzakMarketTheme {
+        NapzakDialog(
+            title = "상품을 정말 삭제할까요?",
+            subTitle = "한번 삭제한 상품은 다시 되돌릴 수 없어요.",
+            dialogColor = NapzakDialogDefault.color.copy(
+                titleColor = NapzakMarketTheme.colors.red
+            ),
+            onConfirmClick = {},
+            onDismissClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LogOutDialogPreview() {
+    NapzakMarketTheme {
+        NapzakDialog(
+            title = "로그아웃 하시겠어요?",
+            onConfirmClick = {},
+            onDismissClick = {},
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
@@ -82,7 +82,7 @@ fun NapzakDialog(
                 .padding(horizontal = 30.dp)
                 .background(
                     color = dialogColor.containerColor,
-                    shape = RoundedCornerShape(14.dp)
+                    shape = RoundedCornerShape(14.dp),
                 ),
         ) {
 
@@ -98,7 +98,7 @@ fun NapzakDialog(
                 Text(
                     text = subTitle,
                     style = NapzakMarketTheme.typography.caption12sb.copy(
-                        color = dialogColor.subTitleColor
+                        color = dialogColor.subTitleColor,
                     ),
                 )
                 Spacer(Modifier.height(24.dp))
@@ -132,15 +132,16 @@ private fun DialogButtons(
                     color = dialogColor.lineColor,
                     start = Offset(0f, 0f),
                     end = Offset(size.width, 0f),
-                    strokeWidth = Dp.Hairline.toPx()
+                    strokeWidth = Dp.Hairline.toPx(),
                 )
                 drawLine(
                     color = dialogColor.lineColor,
                     start = Offset(size.width / 2, 0f),
                     end = Offset(size.width / 2, size.height),
-                    strokeWidth = Dp.Hairline.toPx()
+                    strokeWidth = Dp.Hairline.toPx(),
                 )
-            }) {
+            }
+    ) {
         DialogButton(
             text = confirmText,
             textColor = dialogColor.confirmColor,

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialogDefault.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialogDefault.kt
@@ -1,0 +1,45 @@
+package com.napzak.market.designsystem.component.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
+@Stable
+object NapzakDialogDefault {
+    val color: NapzakDialogColor
+        @Composable get() = NapzakDialogColor(
+            titleColor = NapzakMarketTheme.colors.purple500,
+            subTitleColor = NapzakMarketTheme.colors.gray300,
+            confirmColor = NapzakMarketTheme.colors.gray300,
+            dismissColor = NapzakMarketTheme.colors.gray300,
+            containerColor = NapzakMarketTheme.colors.white,
+            lineColor = NapzakMarketTheme.colors.gray200,
+        )
+}
+
+@Stable
+class NapzakDialogColor(
+    val titleColor: Color,
+    val subTitleColor: Color,
+    val confirmColor: Color,
+    val dismissColor: Color,
+    val containerColor: Color,
+    val lineColor: Color,
+) {
+    fun copy(
+        titleColor: Color = this.titleColor,
+        subTitleColor: Color = this.subTitleColor,
+        confirmColor: Color = this.confirmColor,
+        dismissColor: Color = this.dismissColor,
+        containerColor: Color = this.containerColor,
+        lineColor: Color = this.lineColor,
+    ) = NapzakDialogColor(
+        titleColor = titleColor,
+        subTitleColor = subTitleColor,
+        confirmColor = confirmColor,
+        dismissColor = dismissColor,
+        containerColor = containerColor,
+        lineColor = lineColor,
+    )
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -31,4 +31,8 @@
     <string name="genre_search_hint">어떤 장르의 굿즈인가요? 검색해보세요!</string>
     <string name="genre_search_select_genre">장르 선택</string>
     <string name="genre_search_genre_limit_notice">최대 7개 선택</string>
+
+    <!--AlertDialog-->
+    <string name="dialog_text_confirm">예</string>
+    <string name="dialog_text_dismiss">아니오</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #46 

## Work Description ✏️
- 다이얼로그 UI 구현

## Screenshot 📸
- 프리뷰가 조금 이상하지만 실제론 괜찮습니다!
<img src="https://github.com/user-attachments/assets/b8db30ae-8a9b-4de1-829b-226f65beceb2" width="360"/>

## To Reviewers 📢
- 다이얼로그가 여기저기서 쓰이는 것 같아서 공통 컴포넌트에 만들어뒀습니다!
- 혹시라도 나중에 색상이 바뀔 것을 대비해 NapzakDialogColor도 만들어봤습니다!