### PR TITLE
[FEAT/#64] 네트워크 모듈 추가

### DIFF
--- a/data/dummy/src/main/java/com/napzak/market/dummy/di/DummyServiceModule.kt
+++ b/data/dummy/src/main/java/com/napzak/market/dummy/di/DummyServiceModule.kt
@@ -1,6 +1,7 @@
 package com.napzak.market.dummy.di
 
 import com.napzak.market.dummy.service.DummyService
+import com.napzak.market.remote.qualifier.DUMMY
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,5 +16,5 @@ object DummyServiceModule {
 
     @Provides
     @Singleton
-    fun provideDummyService(retrofit: Retrofit): DummyService = retrofit.create()
+    fun provideDummyService(@DUMMY retrofit: Retrofit): DummyService = retrofit.create()
 }

--- a/data/remote/build.gradle.kts
+++ b/data/remote/build.gradle.kts
@@ -15,15 +15,13 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField(
-                "String",
-                "DUMMY_URL",
-                properties.getProperty("dummy.url")
-            )
+            buildConfigField("String", "DUMMY_URL", properties.getProperty("dummy.url"))
+            buildConfigField("String", "BASE_URL", properties.getProperty("base.url"))
         }
     }
 }
 
 dependencies {
+    implementation(projects.data.local)
     implementation(libs.timber)
 }

--- a/data/remote/src/main/java/com/napzak/market/remote/HeaderInterceptor.kt
+++ b/data/remote/src/main/java/com/napzak/market/remote/HeaderInterceptor.kt
@@ -1,0 +1,25 @@
+package com.napzak.market.remote
+
+import com.napzak.market.local.datastore.TokenDataStore
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import javax.inject.Inject
+
+class HeaderInterceptor @Inject constructor() : Interceptor {
+    @Inject
+    lateinit var tokenDataStore: TokenDataStore
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest = chain.request().newBuilder()
+            .addAccessTokenHeader()
+            .build()
+        return chain.proceed(newRequest)
+    }
+
+    private fun Request.Builder.addAccessTokenHeader(): Request.Builder = runBlocking {
+        val accessToken = tokenDataStore.getAccessToken()
+        addHeader("Authorization", "Bearer $accessToken")
+    }
+}

--- a/data/remote/src/main/java/com/napzak/market/remote/NetworkModule.kt
+++ b/data/remote/src/main/java/com/napzak/market/remote/NetworkModule.kt
@@ -1,11 +1,14 @@
 package com.napzak.market.remote
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.napzak.market.remote.qualifier.DUMMY
+import com.napzak.market.remote.qualifier.JWT
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import data.remote.BuildConfig
+import data.remote.BuildConfig.BASE_URL
 import data.remote.BuildConfig.DUMMY_URL
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
@@ -57,18 +60,36 @@ object NetworkModule {
         }
     }
 
+    @JWT
+    @Provides
+    @Singleton
+    fun providerHeaderInterceptor(): Interceptor = HeaderInterceptor()
+
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        loggingInterceptor: Interceptor
+        loggingInterceptor: Interceptor,
+        @JWT headerInterceptor: Interceptor
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
+        .addInterceptor(headerInterceptor)
         .build()
 
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        client: OkHttpClient,
+        factory: Converter.Factory
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(factory)
+        .build()
 
     // TODO: 더미 레트로핏, 삭제 예정
     @Provides
-    fun provideRetrofit(
+    @DUMMY
+    fun provideDummyRetrofit(
         client: OkHttpClient,
         factory: Converter.Factory
     ): Retrofit = Retrofit.Builder()

--- a/data/remote/src/main/java/com/napzak/market/remote/qualifier/NetworkQualifier.kt
+++ b/data/remote/src/main/java/com/napzak/market/remote/qualifier/NetworkQualifier.kt
@@ -1,0 +1,11 @@
+package com.napzak.market.remote.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class JWT
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DUMMY


### PR DESCRIPTION
## Related issue 🛠
- closed #64 

## Work Description ✏️
- `:data:remote`의 빌드 파일 수정
   - build config 상수 추가
- HeaderInterceptor 구현
- NetworkModule (DI 모듈)에 base url과 연결된 retrofit 모듈 추가

## To Reviewers 📢
- 원활한 API 작업을 위한 밑작업 PR입니다.
- 로그인 관련 로직 구현할 때 토큰 유효성 검증과 같은 토큰 로직은 HeaderInterceptor에서 구현하면 됩니다!
- data 모듈에서 retrofit 객체를 끌고 올땐 hilt qualifier 없이 일반 retrofit을 불러오시면 됩니다! 

### 예시
```kotlin
@Module
@InstallIn(SingletonComponent::class)
object ExampleServiceModule {

    @Provides
    @Singleton
    fun provideExampleService(retrofit: Retrofit): ExampleService = retrofit.create()
}
```
