### PR TITLE
[HOTFIX/#124] genreList의 Item core로 컴포넌트 분리

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/GenreListItem.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/GenreListItem.kt
@@ -1,0 +1,47 @@
+package com.napzak.market.designsystem.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.util.android.noRippleClickable
+
+@Composable
+fun GenreListItem(
+    isSelected: Boolean,
+    genreName: String,
+    onGenreItemClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val textStyle =
+        if (isSelected) NapzakMarketTheme.typography.body14sb
+        else NapzakMarketTheme.typography.body14r
+    val textColor =
+        if (isSelected) NapzakMarketTheme.colors.purple500
+        else NapzakMarketTheme.colors.gray400
+
+    Text(
+        text = genreName,
+        style = textStyle,
+        color = textColor,
+        modifier = Modifier
+            .padding(vertical = 15.dp)
+            .noRippleClickable(onGenreItemClick),
+    )
+}
+
+@Preview
+@Composable
+private fun GenreListItemPrivate(modifier: Modifier = Modifier) {
+    NapzakMarketTheme {
+        GenreListItem(
+            isSelected = false,
+            genreName = "산리오",
+            onGenreItemClick = {},
+            modifier = modifier,
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/GenreListItem.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/GenreListItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -27,6 +28,8 @@ fun GenreListItem(
         text = genreName,
         style = textStyle,
         color = textColor,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier
             .padding(vertical = 15.dp)
             .noRippleClickable(onGenreItemClick),
@@ -39,7 +42,7 @@ private fun GenreListItemPrivate(modifier: Modifier = Modifier) {
     NapzakMarketTheme {
         GenreListItem(
             isSelected = false,
-            genreName = "산리오",
+            genreName = "산리오산리오산리오",
             onGenreItemClick = {},
             modifier = modifier,
         )

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/bottomsheet/GenreSearchBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/bottomsheet/GenreSearchBottomSheet.kt
@@ -37,11 +37,12 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R.drawable.ic_x_button_24
+import com.napzak.market.designsystem.R.string.genre_apply_button
+import com.napzak.market.designsystem.R.string.genre_search_genre_limit_notice
 import com.napzak.market.designsystem.R.string.genre_search_hint
 import com.napzak.market.designsystem.R.string.genre_search_select_genre
-import com.napzak.market.designsystem.R.string.genre_search_genre_limit_notice
-import com.napzak.market.designsystem.R.string.genre_apply_button
 import com.napzak.market.designsystem.component.GenreChipButtonGroup
+import com.napzak.market.designsystem.component.GenreListItem
 import com.napzak.market.designsystem.component.button.NapzakButton
 import com.napzak.market.designsystem.component.textfield.SearchTextField
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -110,10 +111,12 @@ fun GenreSearchBottomSheet(
                         tint = Color.Unspecified,
                         modifier = Modifier
                             .noRippleClickable {
-                                coroutineScope.launch { sheetState.hide() }.invokeOnCompletion {
-                                    focusManager.clearFocus()
-                                    onDismissRequest()
-                                }
+                                coroutineScope
+                                    .launch { sheetState.hide() }
+                                    .invokeOnCompletion {
+                                        focusManager.clearFocus()
+                                        onDismissRequest()
+                                    }
                             }
                             .padding(end = 18.dp),
                     )
@@ -236,20 +239,11 @@ private fun GenreList(
 
         items(genreItems) { genreItem ->
             val isSelected = selectedGenreList.contains(genreItem)
-            val textStyle =
-                if (isSelected) NapzakMarketTheme.typography.body14sb
-                else NapzakMarketTheme.typography.body14r
-            val textColor =
-                if (isSelected) NapzakMarketTheme.colors.purple500
-                else NapzakMarketTheme.colors.gray400
 
-            Text(
-                text = genreItem.genreName,
-                style = textStyle,
-                color = textColor,
-                modifier = Modifier
-                    .padding(vertical = 15.dp)
-                    .noRippleClickable { onGenreItemClick(genreItem, isSelected) },
+            GenreListItem(
+                isSelected = isSelected,
+                genreName = genreItem.genreName,
+                onGenreItemClick = { onGenreItemClick(genreItem, isSelected) }
             )
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #124

## Work Description ✏️
- 기존에 장르 바텀시트 컴포넌트 안에 있던 genreList의 Item core로 컴포넌트 분리

## Screenshot 📸
변경 사항 없습니다.

## Uncompleted Tasks 😅
- [ ]없습니다

## To Reviewers 📢
명교수님 완료 했습니다! 