### PR TITLE
[FEAT]/#148 Presigned Url API usecase 생성 및 model 수정

### DIFF
--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/mapper/PresignedUrlMapper.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/mapper/PresignedUrlMapper.kt
@@ -7,18 +7,22 @@ import com.napzak.market.presigned_url.model.PresignedUrl
 
 /**
  * To domain
- * Map 형태의 데이터를 두 개의 List로 변환(imageNames, urls)
+ * Map 형태의 데이터를 PresignedUrl List 형태로 변환
  */
-fun ProductPresignedUrlResponse.toDomain() = PresignedUrl(
-    imageNames = presignedUrls.keys.toList(),
-    urls = presignedUrls.values.toList(),
-)
+fun ProductPresignedUrlResponse.toDomain() = presignedUrls.map { (imageName, url) ->
+    PresignedUrl(
+        imageName = imageName,
+        url = url,
+    )
+}
 
 /**
  * To domain
- * Map 형태의 데이터를 두 개의 List로 변환(imageNames, urls)
+ * Map 형태의 데이터를 PresignedUrl List 형태로 변환
  */
-fun ProfilePresignedUrlResponse.toDomain() = PresignedUrl(
-    imageNames = presignedUrls.keys.toList(),
-    urls = presignedUrls.values.toList(),
-)
+fun ProfilePresignedUrlResponse.toDomain() = presignedUrls.map { (imageName, url) ->
+    PresignedUrl(
+        imageName = imageName,
+        url = url,
+    )
+}

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepositoryImpl.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepositoryImpl.kt
@@ -10,13 +10,13 @@ class PresignedUrlRepositoryImpl @Inject constructor(
 ) : PresignedUrlRepository {
     override suspend fun getProductPresignedUrls(
         imageTitles: List<String>,
-    ): Result<PresignedUrl> = runCatching {
+    ): Result<List<PresignedUrl>> = runCatching {
         presignedUrlDataSource.getProductPresignedUrl(imageTitles = imageTitles).toDomain()
     }
 
     override suspend fun getProfilePresignedUrls(
         imageTitles: List<String>,
-    ): Result<PresignedUrl> = runCatching {
+    ): Result<List<PresignedUrl>> = runCatching {
         presignedUrlDataSource.getProfilePresignedUrl(imageTitles = imageTitles).toDomain()
     }
 

--- a/domain/presigned-url/build.gradle.kts
+++ b/domain/presigned-url/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("com.napzak.market.buildlogic.convention.kotlin")
 }
+
+dependencies {
+    implementation(libs.javax.inject)
+}

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/model/PresignedUrl.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/model/PresignedUrl.kt
@@ -1,6 +1,6 @@
 package com.napzak.market.presigned_url.model
 
 data class PresignedUrl(
-    val imageNames: List<String>,
-    val urls: List<String>,
+    val imageName: String,
+    val url: String,
 )

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepository.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepository.kt
@@ -3,9 +3,9 @@ package com.napzak.market.presigned_url.repository
 import com.napzak.market.presigned_url.model.PresignedUrl
 
 interface PresignedUrlRepository {
-    suspend fun getProductPresignedUrls(imageTitles: List<String>): Result<PresignedUrl>
+    suspend fun getProductPresignedUrls(imageTitles: List<String>): Result<List<PresignedUrl>>
 
-    suspend fun getProfilePresignedUrls(imageTitles: List<String>): Result<PresignedUrl>
+    suspend fun getProfilePresignedUrls(imageTitles: List<String>): Result<List<PresignedUrl>>
 
     suspend fun putViaPresignedUrl(presignedUrl: String, imageUri: String): Result<Unit>
 }

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/GetProductPresignedUrlUseCase.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/GetProductPresignedUrlUseCase.kt
@@ -1,0 +1,19 @@
+package com.napzak.market.presigned_url.usecase
+
+import com.napzak.market.presigned_url.model.PresignedUrl
+import com.napzak.market.presigned_url.repository.PresignedUrlRepository
+import javax.inject.Inject
+
+class GetProductPresignedUrlUseCase @Inject constructor(
+    private val presignedUrlRepository: PresignedUrlRepository
+) {
+    suspend operator fun invoke(
+        imageTitles: List<String>,
+    ): Result<List<PresignedUrl>> = presignedUrlRepository.getProductPresignedUrls(
+        imageTitles = List(imageTitles.size) { index ->
+            "$IMAGE_TITLE_PREFIX${index + 1}"
+        }
+    )
+}
+
+private const val IMAGE_TITLE_PREFIX = "image_"

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImageUseCase.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImageUseCase.kt
@@ -1,0 +1,16 @@
+package com.napzak.market.presigned_url.usecase
+
+import com.napzak.market.presigned_url.repository.PresignedUrlRepository
+import javax.inject.Inject
+
+class UploadImageUseCase @Inject constructor(
+    private val presignedUrlRepository: PresignedUrlRepository,
+) {
+    suspend operator fun invoke(
+        presignedUrl: String,
+        imageUri: String,
+    ): Result<Unit> = presignedUrlRepository.putViaPresignedUrl(
+        presignedUrl = presignedUrl,
+        imageUri = imageUri,
+    )
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #148 

## Work Description ✏️
- Presiged Url API UseCase 생성했습니다.
  - Url 받아오는건 테스트 해봤는데 PUT 요청은 아직 못했습니다!
- 기존에 사용중이던 PresignedUrl Model을 수정했습니다. 이에 따라 Repository 구현체 및 Mapper 등 관련 부분 수정했습니다.
  - PresignedUrl 내부에 `imageName`과 `url`로 수정하고, Repository에서 List<PresignedUrl>을 리턴하도록 수정했습니다.
 
## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢