### PR TITLE
[FEAT/#167] 마이페이지 UI 보강

### DIFF
--- a/feature/main/src/main/java/com/napzak/market/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.main
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -14,8 +15,19 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             NapzakMarketTheme {
-                MainScreen()
+                MainScreen(
+                    restartApplication = ::restartApplication
+                )
             }
+        }
+    }
+
+
+    private fun restartApplication() {
+        Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(this)
         }
     }
 }

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -41,6 +41,7 @@ import com.napzak.market.main.component.MainRegisterDialog
 import com.napzak.market.mypage.navigation.mypageGraph
 import com.napzak.market.mypage.setting.navigation.navigateToSettings
 import com.napzak.market.mypage.setting.navigation.settingsGraph
+import com.napzak.market.mypage.signout.navigation.navigateToSignOut
 import com.napzak.market.mypage.signout.navigation.signOutGraph
 import com.napzak.market.onboarding.navigation.Terms
 import com.napzak.market.onboarding.navigation.onboardingGraph
@@ -281,7 +282,7 @@ private fun MainNavHost(
         settingsGraph(
             navigateToBack = navigator::navigateUp,
             onLogoutConfirm = restartApplication,
-            onWithdrawClick = { /* TODO: 탈퇴 처리 */ }
+            onWithdrawClick = navigator.navController::navigateToSignOut
         )
 
         signOutGraph(

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.napzak.market.main
 
-import android.content.Intent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.Box
@@ -67,6 +66,7 @@ import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun MainScreen(
+    restartApplication: () -> Unit,
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -127,6 +127,7 @@ fun MainScreen(
 
                 MainNavHost(
                     navigator = navigator,
+                    restartApplication = restartApplication,
                     modifier = Modifier.padding(innerPadding),
                 )
             }
@@ -137,6 +138,7 @@ fun MainScreen(
 @Composable
 private fun MainNavHost(
     navigator: MainNavigator,
+    restartApplication: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -278,21 +280,14 @@ private fun MainNavHost(
 
         settingsGraph(
             navigateToBack = navigator::navigateUp,
-            onLogoutConfirm = { /* TODO: 로그아웃 처리 */ },
+            onLogoutConfirm = restartApplication,
             onWithdrawClick = { /* TODO: 탈퇴 처리 */ }
         )
 
         signOutGraph(
             navController = navigator.navController,
             onNavigateUp = navigator::navigateUp,
-            restartApp = {
-                Intent(context, MainActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    context.startActivity(this)
-                }
-
-            },
+            restartApp = restartApplication,
             modifier = modifier,
         )
     }

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -142,8 +141,6 @@ private fun MainNavHost(
     restartApplication: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-
     NavHost(
         enterTransition = {
             EnterTransition.None

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -289,7 +289,6 @@ private fun MainNavHost(
             navController = navigator.navController,
             onNavigateUp = navigator::navigateUp,
             restartApp = restartApplication,
-            modifier = modifier,
         )
     }
 }

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingSideEffect.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingSideEffect.kt
@@ -1,0 +1,5 @@
+package com.napzak.market.mypage.setting
+
+sealed class SettingSideEffect {
+    data object OnSignOutComplete : SettingSideEffect()
+}

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingsScreen.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,7 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.mypage.R.string.settings_button_logout
@@ -43,11 +46,20 @@ fun SettingsRoute(
     openWebLink: (String) -> Unit,
     viewModel: SettingViewModel = hiltViewModel()
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
     val state by viewModel.settingInfo.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+        viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle).collect {
+            when (it) {
+                is SettingSideEffect.OnSignOutComplete -> onLogoutConfirm()
+            }
+        }
+    }
 
     SettingsScreen(
         onBackClick = onBackClick,
-        onLogoutConfirm = onLogoutConfirm,
+        onLogoutConfirm = viewModel::signOutUser,
         onWithdrawClick = onWithdrawClick,
         onNoticeClick = { if (state.noticeLink.isNotBlank()) openWebLink(state.noticeLink) },
         onTermsClick = { if (state.termsLink.isNotBlank()) openWebLink(state.termsLink) },

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingsScreen.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/setting/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -26,6 +27,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
+import com.napzak.market.designsystem.component.topbar.NavigateUpTopBar
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.mypage.R.string.settings_button_logout
 import com.napzak.market.feature.mypage.R.string.settings_button_withdraw
@@ -33,8 +35,8 @@ import com.napzak.market.feature.mypage.R.string.settings_logout_dialog_cancel_b
 import com.napzak.market.feature.mypage.R.string.settings_logout_dialog_confirm_button
 import com.napzak.market.feature.mypage.R.string.settings_logout_dialog_title
 import com.napzak.market.feature.mypage.R.string.settings_section_service_info_title
+import com.napzak.market.feature.mypage.R.string.settings_topbar_title
 import com.napzak.market.mypage.setting.component.SettingItem
-import com.napzak.market.mypage.setting.component.SettingsTopBar
 import com.napzak.market.mypage.setting.model.SettingViewModel
 import com.napzak.market.util.android.noRippleClickable
 
@@ -83,8 +85,12 @@ fun SettingsScreen(
 
     Scaffold(
         topBar = {
-            SettingsTopBar(onBackClick = onBackClick)
-        }
+            NavigateUpTopBar(
+                title = stringResource(id = settings_topbar_title),
+                onNavigateUp = onBackClick,
+            )
+        },
+        modifier = Modifier.systemBarsPadding(),
     ) { padding ->
         Column(
             modifier = Modifier

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/setting/model/SettingViewModel.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/setting/model/SettingViewModel.kt
@@ -2,23 +2,31 @@ package com.napzak.market.mypage.setting.model
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.napzak.market.mypage.setting.SettingSideEffect
 import com.napzak.market.store.model.SettingInfo
 import com.napzak.market.store.repository.SettingRepository
+import com.napzak.market.store.repository.StoreRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import timber.log.Timber
+import javax.inject.Inject
 
 @HiltViewModel
 class SettingViewModel @Inject constructor(
-    private val settingRepository: SettingRepository
+    private val settingRepository: SettingRepository,
+    private val storeRepository: StoreRepository,
 ) : ViewModel() {
 
     private val _settingInfo = MutableStateFlow(SettingInfo("", "", "", ""))
     val settingInfo: StateFlow<SettingInfo> = _settingInfo.asStateFlow()
+
+    private val _sideEffect = Channel<SettingSideEffect>()
+    val sideEffect = _sideEffect.receiveAsFlow()
 
     init {
         fetchSettingInfo()
@@ -30,5 +38,13 @@ class SettingViewModel @Inject constructor(
             .onFailure { throwable ->
                 Timber.e(throwable, "설정 정보 가져오기 실패")
             }
+    }
+
+    fun signOutUser() = viewModelScope.launch {
+        storeRepository.logout()
+            .onSuccess {
+                _sideEffect.send(SettingSideEffect.OnSignOutComplete)
+            }
+            .onFailure(Timber::e)
     }
 }

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/signout/navigation/SignOutNavigation.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/signout/navigation/SignOutNavigation.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.mypage.signout.navigation
 
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -28,8 +29,9 @@ fun NavGraphBuilder.signOutGraph(
     navController: NavHostController,
     onNavigateUp: () -> Unit,
     restartApp: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
+    val modifier = Modifier.systemBarsPadding()
+
     horizontalSlideNavigation<SignOut, Route>(
         startDestination = SignOutReason,
         screens = listOf(SignOutReason, SignOutDetail, SignOutConfirm),


### PR DESCRIPTION
## Related issue 🛠
- closed #167 

## Work Description ✏️
- 앱 재실행 로직 함수화, MainActivity로 이동
- 설정화면 -> 탈퇴화면 화면전환 함수 적용
- 로그아웃 기능 연결
- 설정화면 탑바 컴포넌트 변경 및 시스템바 패딩 적용

## To Reviewers 📢
- 설정화면의 로그아웃과 탈퇴 기능 확인했습니다!
- MainScreen에서 수정자를 넘겨주지 않고 설정화면 및 탈퇴화면 내부에서 처리하도록 수정했습니다!