### PR TITLE
[FEAT/#183] 메인화면들에 BackHandler 추가

### DIFF
--- a/feature/explore/src/main/java/com/napzak/market/explore/navigation/ExploreNavigation.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/navigation/ExploreNavigation.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.explore.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -36,6 +37,10 @@ fun NavGraphBuilder.exploreGraph(
     modifier: Modifier = Modifier,
 ) {
     composable<Explore> {
+        BackHandler {
+            navigateToUp()
+        }
+
         ExploreRoute(
             onSearchNavigate = navigateToSearch,
             onGenreDetailNavigate = navigateToGenreDetail,

--- a/feature/home/src/main/java/com/napzak/market/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/navigation/HomeNavigation.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.home.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -12,6 +13,7 @@ import kotlinx.serialization.Serializable
 fun NavController.navigateToHome(navOptions: NavOptions? = null) = navigate(Home, navOptions)
 
 fun NavGraphBuilder.homeGraph(
+    navigateToUp: () -> Unit,
     navigateToSearch: () -> Unit,
     navigateToProductDetail: (Long) -> Unit,
     navigateToExploreSell: () -> Unit,
@@ -19,6 +21,10 @@ fun NavGraphBuilder.homeGraph(
     modifier: Modifier = Modifier,
 ) {
     composable<Home> {
+        BackHandler {
+            navigateToUp()
+        }
+
         HomeRoute(
             onSearchNavigate = navigateToSearch,
             onProductDetailNavigate = navigateToProductDetail,

--- a/feature/main/src/main/java/com/napzak/market/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainNavigator.kt
@@ -13,10 +13,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.napzak.market.explore.navigation.navigateToExplore
 import com.napzak.market.home.navigation.navigateToHome
-import com.napzak.market.splash.navigation.Splash
-import com.napzak.market.onboarding.navigation.Terms
-import com.napzak.market.login.navigation.Login
 import com.napzak.market.mypage.navigation.navigateToMyPage
+import com.napzak.market.splash.navigation.Splash
 
 class MainNavigator(
     val navController: NavHostController,
@@ -41,7 +39,6 @@ class MainNavigator(
         val navOptions = navOptions {
             navController.currentDestination?.route?.let {
                 popUpTo(it) {
-                    inclusive = true
                     saveState = true
                 }
             }

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -118,7 +118,7 @@ fun MainScreen(
                         navigator.navController.navigateToPurchaseRegistration()
                         navigator.dismissRegisterDialog()
                     },
-                    onDismissRequest = navigator::dismissRegisterDialog,
+                    onDismissRequest = navigator::navigateUp,
                     modifier = Modifier
                         .padding(innerPadding)
                         .zIndex(1f),
@@ -185,6 +185,7 @@ private fun MainNavHost(
         )
 
         homeGraph(
+            navigateToUp = navigator::navigateUp,
             navigateToSearch = { navigator.navController.navigateToSearch() },
             navigateToProductDetail = { navigator.navController.navigateToProductDetail(it) },
             navigateToExploreSell = {
@@ -203,7 +204,7 @@ private fun MainNavHost(
         )
 
         exploreGraph(
-            navigateToUp = { navigator.navController.popBackStack() },
+            navigateToUp = navigator::navigateUp,
             navigateToHome = { navigator.navController.popBackStack(Home, inclusive = false) },
             navigateToSearch = { navigator.navController.navigateToSearch() },
             navigateToGenreDetail = { navigator.navController.navigateToGenreDetail(it) },
@@ -259,6 +260,7 @@ private fun MainNavHost(
         )
 
         mypageGraph(
+            navigateToUp = navigator::navigateUp,
             navigateToMyMarket = { navigator.navController.navigateToStore(it) },
             navigateToSales = { /* TODO: 판매내역 화면으로 이동 */ },
             navigateToPurchase = { /* TODO: 구매내역 화면으로 이동 */ },

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/navigation/MyPageNavigation.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.mypage.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -13,6 +14,7 @@ fun NavController.navigateToMyPage(navOptions: NavOptions? = null) =
     navigate(MyPageNavigation, navOptions)
 
 fun NavGraphBuilder.mypageGraph(
+    navigateToUp: () -> Unit,
     navigateToMyMarket: (Long) -> Unit,
     navigateToSales: () -> Unit,
     navigateToPurchase: () -> Unit,
@@ -23,6 +25,10 @@ fun NavGraphBuilder.mypageGraph(
     modifier: Modifier = Modifier,
 ) {
     composable<MyPageNavigation> {
+        BackHandler {
+            navigateToUp()
+        }
+
         MyPageRoute(
             onMyMarketClick = navigateToMyMarket,
             onSalesClick = navigateToSales,


### PR DESCRIPTION
## Related issue 🛠
- closed #183 

## Work Description ✏️
- BackHandler 호출을 통해 등록 다이얼로그 제어 기능 구현

## Screenshot 📸

https://github.com/user-attachments/assets/e894c5d4-4808-4854-a87f-54319b7f226e

## To Reviewers 📢
- 납작 플래시 해결했습니다~!
- MainScreen에서 BackHandler를 호출하니까 그 위에 화면들이 띄워졌을 때 MainScreen의 BackHandler가 동작하지 않더라고요,,,
   그래서 등록 다이얼로그가 등장하는 화면들의 navGraph 함수 안에 BackHandler를 호출해뒀습니다!
- 혹시 더 좋은 방법 있다면 제안해주세요!
