### PR TITLE
[Feat/#203] shadow 확장함수 구현

### DIFF
--- a/core/util/src/main/java/com/napzak/market/util/android/NapzakShadowExt.kt
+++ b/core/util/src/main/java/com/napzak/market/util/android/NapzakShadowExt.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.napzak.market.util.android.model.ShadowDirection
 
 /**
@@ -21,10 +20,10 @@ import com.napzak.market.util.android.model.ShadowDirection
  */
 
 fun Modifier.napzakGradientShadow(
-    height: Dp = 12.dp,
-    startColor: Color = Color(0x33000000),
-    endColor: Color = Color.Transparent,
-    direction: ShadowDirection = ShadowDirection.Bottom,
+    height: Dp,
+    startColor: Color,
+    endColor: Color,
+    direction: ShadowDirection,
 ): Modifier = this.then(
     Modifier.drawWithContent {
         drawContent()

--- a/core/util/src/main/java/com/napzak/market/util/android/NapzakShadowExt.kt
+++ b/core/util/src/main/java/com/napzak/market/util/android/NapzakShadowExt.kt
@@ -1,0 +1,53 @@
+package com.napzak.market.util.android
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.napzak.market.util.android.model.ShadowDirection
+
+/**
+ * 컴포저블의 상/하/좌/우단에 자연스러운 그라데이션 그림자를 추가하는 Modifier 확장 함수입니다.
+ *
+ * @param height 그림자 높이(dp). 그림자가 퍼지는 범위를 조절합니다.
+ * @param startColor 그림자의 시작 색상. 일반적으로 투명도 있는 블랙 계열을 사용합니다.
+ * @param endColor 그림자의 끝 색상. 보통 Color.Transparent로 자연스러운 fade-out 효과를 줍니다.
+ * @param direction 그림자 방향 (Top 또는 Bottom). 현재는 수직 방향만 지원합니다.
+ *
+ */
+
+fun Modifier.napzakGradientShadow(
+    height: Dp = 12.dp,
+    startColor: Color = Color(0x33000000),
+    endColor: Color = Color.Transparent,
+    direction: ShadowDirection = ShadowDirection.Bottom,
+): Modifier = this.then(
+    Modifier.drawWithContent {
+        drawContent()
+
+        val shadowHeightPx = height.toPx()
+        val gradientBrush = Brush.verticalGradient(
+            colors = listOf(startColor, endColor)
+        )
+
+        when (direction) {
+            ShadowDirection.Bottom -> drawRect(
+                brush = gradientBrush,
+                topLeft = Offset(0f, size.height - shadowHeightPx),
+                size = Size(size.width, shadowHeightPx),
+            )
+
+            ShadowDirection.Top -> drawRect(
+                brush = gradientBrush,
+                topLeft = Offset(0f, 0f),
+                size = Size(size.width, shadowHeightPx),
+            )
+
+            else -> Unit
+        }
+    }
+)

--- a/core/util/src/main/java/com/napzak/market/util/android/model/ShadowDirection.kt
+++ b/core/util/src/main/java/com/napzak/market/util/android/model/ShadowDirection.kt
@@ -1,0 +1,15 @@
+package com.napzak.market.util.android.model
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class ShadowDirection(
+    val offsetX: Dp,
+    val offsetY: Dp
+) {
+    Top(0.dp, -1.dp),
+    Bottom(0.dp, 1.dp),
+    Start(-1.dp, 0.dp),
+    End(1.dp, 0.dp),
+    None(0.dp, 0.dp),
+}

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/GenreScreen.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/GenreScreen.kt
@@ -52,6 +52,8 @@ import com.napzak.market.feature.onboarding.R.string.onboarding_genre_title
 import com.napzak.market.onboarding.genre.component.GenreGridList
 import com.napzak.market.onboarding.genre.model.GenreUiModel
 import com.napzak.market.onboarding.genre.model.GenreUiState
+import com.napzak.market.util.android.model.ShadowDirection
+import com.napzak.market.util.android.napzakGradientShadow
 import com.napzak.market.util.android.noRippleClickable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -120,7 +122,7 @@ fun GenreScreen(
         modifier = modifier
             .fillMaxSize()
             .background(NapzakMarketTheme.colors.white)
-            .padding(horizontal = 20.dp, vertical = 10.dp)
+            .padding(vertical = 10.dp)
             .padding(
                 bottom = WindowInsets.navigationBars
                     .asPaddingValues()
@@ -132,7 +134,7 @@ fun GenreScreen(
         ) {
             Spacer(modifier = Modifier.height(50.dp))
 
-            GenreTopBar(onBackClick = onBackClick)
+            GenreTopBar(onBackClick = onBackClick,)
 
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -148,7 +150,8 @@ fun GenreScreen(
                 onSearchClick = onSearchTextSubmit,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 16.dp),
+                    .padding(bottom = 16.dp)
+                    .padding(horizontal = 20.dp),
                 readOnly = false,
                 enabled = true,
             )
@@ -162,16 +165,31 @@ fun GenreScreen(
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 12.dp),
+                        .padding(bottom = 12.dp)
+                        .padding(horizontal = 20.dp),
                     contentPaddingValues = PaddingValues(vertical = 8.dp),
                 )
             }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .napzakGradientShadow(
+                        height = 2.dp,
+                        startColor = Color(0x0D000000),
+                        endColor = Color.Transparent,
+                        direction = ShadowDirection.Bottom,
+                    )
+            )
 
             Box(modifier = Modifier.weight(1f)) {
                 GenreGridList(
                     genres = uiState.genres,
                     onGenreClick = onGenreClick,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 20.dp),
                 )
             }
         }
@@ -179,7 +197,8 @@ fun GenreScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.BottomCenter),
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (isShownSnackBar) {
@@ -216,7 +235,8 @@ private fun GenreTopBar(
 ) {
     Row(
         modifier = modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -240,29 +260,31 @@ private fun GenreTopBar(
 
 @Composable
 private fun GenreTitleSection() {
-    Text(
-        text = stringResource(onboarding_genre_selected_limitation),
-        style = NapzakMarketTheme.typography.caption10sb,
-        color = NapzakMarketTheme.colors.purple500,
-    )
+    Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+        Text(
+            text = stringResource(onboarding_genre_selected_limitation),
+            style = NapzakMarketTheme.typography.caption10sb,
+            color = NapzakMarketTheme.colors.purple500,
+        )
 
-    Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
-    Text(
-        text = stringResource(onboarding_genre_title),
-        style = NapzakMarketTheme.typography.title20b,
-        color = NapzakMarketTheme.colors.gray400,
-    )
+        Text(
+            text = stringResource(onboarding_genre_title),
+            style = NapzakMarketTheme.typography.title20b,
+            color = NapzakMarketTheme.colors.gray400,
+        )
 
-    Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
-    Text(
-        text = stringResource(onboarding_genre_sub_title),
-        style = NapzakMarketTheme.typography.caption12r,
-        color = NapzakMarketTheme.colors.gray300,
-    )
+        Text(
+            text = stringResource(onboarding_genre_sub_title),
+            style = NapzakMarketTheme.typography.caption12r,
+            color = NapzakMarketTheme.colors.gray300,
+        )
 
-    Spacer(modifier = Modifier.height(18.dp))
+        Spacer(modifier = Modifier.height(18.dp))
+    }
 }
 
 @Preview(showBackground = true)

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/component/GenreGridList.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/component/GenreGridList.kt
@@ -35,10 +35,15 @@ fun GenreGridList(
     ) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
             items(
                 items = genres,
                 key = { it.name },


### PR DESCRIPTION
## Related issue 🛠
- closed #203

## Work Description ✏️
- shadow 확장함수 구현
- 장르온보딩에 shadow 추가

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/93a05993-7995-4784-9d77-36869d5d8c56" width="360"/>

## Uncompleted Tasks 😅

## To Reviewers 📢
[horizontal 패딩 추가 ]
기존에는 전체에 horizontal 패딩을 넣어줬는데 shadow 영역박스는 해당 패딩값이 들어가면 안되서 고민을 하다가 일단 급하게 컴포넌트 각각에 패딩 값을 넣어줬습니다...! 나중에 리펙으로 구조변경해서 개별적으로 들어가있는 패딩값은 수정하겠습니다..!

[확장함수 사용법]
주석으로 사용법에 대해서 적어놨습니다! 혹시라도 어떻게 사용해야하는지 감이 안오시면 장르온보딩 부분을 참고해주세요!