### PR TITLE
[REFACTOR/#236] 탐색 탭 QA 반영

### DIFF
--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -93,7 +93,7 @@ internal fun ExploreRoute(
         viewModel.updateGenreSearchResult()
     }
 
-    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+    LaunchedEffect(Unit) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
                 when (sideEffect) {

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -69,12 +69,6 @@ internal fun ExploreRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val bottomSheetState by viewModel.bottomSheetState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.updateSortOption(viewModel.sortType)
-        viewModel.updateTradeType(viewModel.tradeType)
-        viewModel.updateGenreItemsInBottomSheet()
-    }
-
     LaunchedEffect(
         uiState.selectedTab,
         uiState.filteredGenres,
@@ -124,7 +118,7 @@ internal fun ExploreRoute(
 
 @Composable
 private fun ExploreScreen(
-    searchTerm: String,
+    searchTerm: String?,
     uiState: ExploreUiState,
     bottomSheetState: ExploreBottomSheetState,
     onDismissRequest: (BottomSheetType) -> Unit,
@@ -190,7 +184,7 @@ private fun ExploreScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExploreSuccessScreen(
-    searchTerm: String,
+    searchTerm: String?,
     selectedTab: TradeType,
     filteredGenres: List<Genre>,
     isUnopenSelected: Boolean,
@@ -226,7 +220,7 @@ private fun ExploreSuccessScreen(
             .padding(top = 54.dp),
     ) {
         ExploreSearchTextField(
-            searchTerm = searchTerm,
+            searchTerm = searchTerm ?: "",
             modifier = Modifier
                 .padding(horizontal = 20.dp)
                 .noRippleClickable(onSearchNavigate),

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -139,7 +139,7 @@ internal fun ExploreRoute(
         },
         onProductDetailNavigate = onProductDetailNavigate,
         onLikeButtonClick = { id, value ->
-            viewModel.updateProductIsInterested(productId = id, isLiked = value)
+            viewModel.updateProductIsInterested(productId = id, isInterested = value)
         },
         modifier = modifier,
     )

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.SpanStyle
@@ -32,17 +33,22 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.BottomSheetType
 import com.napzak.market.common.type.SortType
 import com.napzak.market.common.type.TradeStatusType
 import com.napzak.market.common.type.TradeType
 import com.napzak.market.designsystem.R.drawable.ic_down_chevron
+import com.napzak.market.designsystem.R.string.heart_click_snackbar_message
 import com.napzak.market.designsystem.component.GenreFilterChip
 import com.napzak.market.designsystem.component.productItem.NapzakLargeProductItem
 import com.napzak.market.designsystem.component.tabbar.TradeTypeTabBar
 import com.napzak.market.designsystem.component.textfield.SearchTextField
+import com.napzak.market.designsystem.component.toast.LocalNapzakToast
+import com.napzak.market.designsystem.component.toast.ToastType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.explore.component.BasicFilterChip
 import com.napzak.market.explore.component.ExploreBottomSheetScreen
@@ -66,6 +72,10 @@ internal fun ExploreRoute(
     modifier: Modifier = Modifier,
     viewModel: ExploreViewModel = hiltViewModel(),
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val toast = LocalNapzakToast.current
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val bottomSheetState by viewModel.bottomSheetState.collectAsStateWithLifecycle()
 
@@ -81,6 +91,25 @@ internal fun ExploreRoute(
 
     LaunchedEffect(viewModel.genreSearchTerm) {
         viewModel.updateGenreSearchResult()
+    }
+
+    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+        viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collect { sideEffect ->
+                when (sideEffect) {
+                    is ExploreSideEffect.ShowHeartToast -> {
+                        toast.makeText(
+                            toastType = ToastType.HEART,
+                            message = context.getString(heart_click_snackbar_message),
+                            yOffset = toast.toastOffsetWithBottomBar()
+                        )
+                    }
+
+                    is ExploreSideEffect.CancelToast -> {
+                        toast.cancel()
+                    }
+                }
+            }
     }
 
     ExploreScreen(

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreSideEffect.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreSideEffect.kt
@@ -1,0 +1,6 @@
+package com.napzak.market.explore
+
+sealed interface ExploreSideEffect {
+    data object ShowHeartToast : ExploreSideEffect
+    data object CancelToast : ExploreSideEffect
+}

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -208,7 +208,7 @@ internal class ExploreViewModel @Inject constructor(
     }
 
     private fun updateGenreItemsInBottomSheet() = viewModelScope.launch {
-        genreNameRepository.getGenreNames(cursor = null, size = 39)
+        genreNameRepository.getGenreNames(cursor = null, size = INIT_GENRE_LIST_SIZE)
             .onSuccess { genres ->
                 _uiState.update { currentState ->
                     currentState.copy(
@@ -318,6 +318,7 @@ internal class ExploreViewModel @Inject constructor(
 
     companion object {
         private const val DEBOUNCE_DELAY = 500L
+        private const val INIT_GENRE_LIST_SIZE = 39
         private const val SEARCH_TERM_KEY = "searchTerm"
         private const val SORT_TYPE_KEY = "sortType"
         private const val TRADE_TYPE_KEY = "tradeType"

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -175,7 +175,7 @@ internal class ExploreViewModel @Inject constructor(
     }
 
     private fun updateGenreItemsInBottomSheet() = viewModelScope.launch {
-        genreNameRepository.getGenreNames(cursor = null)
+        genreNameRepository.getGenreNames(cursor = null, size = 39)
             .onSuccess { genres ->
                 _uiState.update { currentState ->
                     currentState.copy(

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -36,9 +36,9 @@ internal class ExploreViewModel @Inject constructor(
     private val genreNameRepository: GenreNameRepository,
     private val setInterestProductUseCase: SetInterestProductUseCase,
 ) : ViewModel() {
-    val searchTerm: String = savedStateHandle.get<String>(SEARCH_TERM_KEY) ?: ""
-    val sortType: SortType = savedStateHandle.get<SortType>(SORT_TYPE_KEY) ?: SortType.RECENT
-    val tradeType: TradeType = savedStateHandle.get<TradeType>(TRADE_TYPE_KEY) ?: TradeType.SELL
+    val searchTerm = savedStateHandle.get<String>(SEARCH_TERM_KEY)
+    val sortType = savedStateHandle.get<SortType>(SORT_TYPE_KEY)
+    val tradeType = savedStateHandle.get<TradeType>(TRADE_TYPE_KEY)
 
     private val _uiState = MutableStateFlow(ExploreUiState())
     val uiState = _uiState.asStateFlow()
@@ -49,9 +49,15 @@ internal class ExploreViewModel @Inject constructor(
     private val _genreSearchTerm = MutableStateFlow("")
     val genreSearchTerm = _genreSearchTerm.asStateFlow()
 
+    init {
+        if (sortType != null) updateSortOption(sortType)
+        if (tradeType != null) updateTradeType(tradeType)
+        updateGenreItemsInBottomSheet()
+    }
+
     fun updateExploreInformation() = viewModelScope.launch {
         val parameters = with(uiState.value) {
-            if (searchTerm.isEmpty()) {
+            if (searchTerm.isNullOrEmpty()) {
                 ExploreParameters(
                     sort = sortOption.toString(),
                     genreIds = filteredGenres.extractGenreIds(),
@@ -73,7 +79,7 @@ internal class ExploreViewModel @Inject constructor(
 
         when (uiState.value.selectedTab) {
             TradeType.BUY -> {
-                if (searchTerm.isEmpty()) {
+                if (searchTerm.isNullOrEmpty()) {
                     productExploreRepository.getExploreBuyProducts(parameters as ExploreParameters)
                         .onSuccess {
                             updateLoadState(
@@ -103,7 +109,7 @@ internal class ExploreViewModel @Inject constructor(
             }
 
             TradeType.SELL -> {
-                if (searchTerm.isEmpty()) {
+                if (searchTerm.isNullOrEmpty()) {
                     productExploreRepository.getExploreSellProducts(parameters as ExploreParameters)
                         .onSuccess {
                             updateLoadState(
@@ -163,7 +169,7 @@ internal class ExploreViewModel @Inject constructor(
         }
     }
 
-    fun updateGenreItemsInBottomSheet() = viewModelScope.launch {
+    private fun updateGenreItemsInBottomSheet() = viewModelScope.launch {
         genreNameRepository.getGenreNames(cursor = null)
             .onSuccess { genres ->
                 _uiState.update { currentState ->

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -19,11 +19,13 @@ import com.napzak.market.product.model.SearchParameters
 import com.napzak.market.product.repository.ProductExploreRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -48,6 +50,9 @@ internal class ExploreViewModel @Inject constructor(
 
     private val _genreSearchTerm = MutableStateFlow("")
     val genreSearchTerm = _genreSearchTerm.asStateFlow()
+
+    private val _sideEffect = Channel<ExploreSideEffect>()
+    val sideEffect = _sideEffect.receiveAsFlow()
 
     init {
         if (sortType != null) updateSortOption(sortType)
@@ -258,6 +263,12 @@ internal class ExploreViewModel @Inject constructor(
                         ExploreProducts(state.data.productCount, updatedProducts)
                     )
                 )
+
+                if (!isLiked) {
+                    _sideEffect.send(ExploreSideEffect.ShowHeartToast)
+                } else {
+                    _sideEffect.send(ExploreSideEffect.CancelToast)
+                }
             }
 
             else -> {}


### PR DESCRIPTION
## Related issue 🛠
- closed #236

## Work Description ✏️
- 탐색 > 상세에서 뒤로가기 할 때 필터 초기화 되는 오류 해결
- 좋아요 클릭 시 토스트 활성화
- 장르 바텀 시트 기본 장르 리스트 39개로 제한

## Screenshot 📸

https://github.com/user-attachments/assets/af874738-b18e-49dc-9475-3b8672c9d8a1



## Uncompleted Tasks 😅
- [ ] 없습니다

## To Reviewers 📢
늦어서 죄송합니다!! 디바운스 부분도 모두 수정되었습니다!