### PR TITLE
[FIX/#240] 닉네임 검증에서 초성 및 중성이 입력된 경우의 토스트메세지 수정

### DIFF
--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -18,5 +18,5 @@
     <string name="onboarding_error_whitespace">공백은 사용할 수 없어요.</string>
     <string name="onboarding_error_special_char">특수문자는 사용할 수 없어요.</string>
     <string name="onboarding_error_only_numbers">숫자만으로는 이름을 만들 수 없어요.</string>
-    <string name="onboarding_error_only_consonants">초성은 입력할 수 없어요.</string>
+    <string name="onboarding_error_only_consonants">이름은 ‘가’, ‘나’처럼 완성된 글자로만 입력해 주세요.</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #240 

## Work Description ✏️
- 닉네임 검증에서 초성 및 중성이 입력되는 경우를 위한 토스트메세지 수정

## Screenshot 📸

https://github.com/user-attachments/assets/49861668-365d-4916-bfb5-5163c16c1b11

## Uncompleted Tasks 😅

## To Reviewers 📢