### PR TITLE
[UI/#255] 이미지 확대 화면 구현

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
@@ -20,15 +20,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.R.drawable.ic_arrow_left
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
-import com.napzak.market.ui_util.ScreenPreview
 import com.napzak.market.ui_util.noRippleClickable
 
 @Composable
@@ -42,12 +40,13 @@ fun ZoomableImageScreen(
 
     Box(
         modifier = modifier
+            .fillMaxSize()
             .background(color = NapzakMarketTheme.colors.black)
             .onGloballyPositioned { rootSize = it.size },
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
     ) {
         Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left),
+            imageVector = ImageVector.vectorResource(ic_arrow_left),
             contentDescription = null,
             tint = NapzakMarketTheme.colors.white,
             modifier = Modifier
@@ -59,7 +58,7 @@ fun ZoomableImageScreen(
         AsyncImage(
             model = imageRequest,
             contentDescription = contentDescription,
-            modifier = Modifier.zoomable(rootSize)
+            modifier = Modifier.zoomable(rootSize),
         )
     }
 }
@@ -118,17 +117,4 @@ private fun Modifier.zoomable(
             translationY = offset.y,
         )
         .transformable(state = state)
-}
-
-@ScreenPreview
-@Composable
-private fun ZoomableImageScreenPreview() {
-    ZoomableImageScreen(
-        imageRequest = ImageRequest.Builder(LocalContext.current)
-            .data(R.drawable.img_empty_chat_list)
-            .build(),
-        contentDescription = null,
-        modifier = Modifier.fillMaxSize(),
-        onBackClick = {},
-    )
 }

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
@@ -1,0 +1,134 @@
+package com.napzak.market.designsystem.component.image
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.ui_util.ScreenPreview
+import com.napzak.market.ui_util.noRippleClickable
+
+@Composable
+fun ZoomableImageScreen(
+    imageRequest: ImageRequest,
+    contentDescription: String?,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var rootSize by remember { mutableStateOf(IntSize.Zero) }
+
+    Box(
+        modifier = modifier
+            .background(color = NapzakMarketTheme.colors.black)
+            .onGloballyPositioned { rootSize = it.size },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left),
+            contentDescription = null,
+            tint = NapzakMarketTheme.colors.white,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(start = 20.dp, top = 34.dp)
+                .noRippleClickable(onClick = onBackClick),
+        )
+
+        AsyncImage(
+            model = imageRequest,
+            contentDescription = contentDescription,
+            modifier = Modifier.zoomable(rootSize)
+        )
+    }
+}
+
+// TODO: 안정화되면 ui_util로 이동
+private fun Modifier.zoomable(
+    parentLayoutSize: IntSize,
+    scaleRange: ClosedFloatingPointRange<Float> = 1f..5f,
+) = composed {
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+    var originalIntSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val state = rememberTransformableState { zoomChange, offsetChange, _ ->
+        scale = (scale * zoomChange).coerceIn(scaleRange)
+        val offsetConstraints = Offset(
+            x = (originalIntSize.width * scale - parentLayoutSize.width) / 2f,
+            y = (originalIntSize.height * scale - parentLayoutSize.height) / 2f,
+        )
+
+        val offsetX = when {
+            scale * originalIntSize.width < parentLayoutSize.width -> 0f
+
+            offset.x + offsetChange.x !in -offsetConstraints.x..offsetConstraints.x -> {
+                offset.x.coerceIn(
+                    minimumValue = -offsetConstraints.x,
+                    maximumValue = offsetConstraints.x,
+                )
+            }
+
+            else -> offset.x + offsetChange.x * scale
+        }
+        val offsetY = when {
+            scale * originalIntSize.height < parentLayoutSize.height -> 0f
+
+            offset.y + offsetChange.y !in -offsetConstraints.y..offsetConstraints.y -> {
+                offset.y.coerceIn(
+                    minimumValue = -offsetConstraints.y,
+                    maximumValue = offsetConstraints.y,
+                )
+            }
+
+            else -> offset.y + offsetChange.y * scale
+        }
+        offset = Offset(x = offsetX, y = offsetY)
+    }
+
+    this
+        .onGloballyPositioned {
+            originalIntSize = it.size
+        }
+        .graphicsLayer(
+            scaleX = scale,
+            scaleY = scale,
+            translationX = offset.x,
+            translationY = offset.y,
+        )
+        .transformable(state = state)
+}
+
+@ScreenPreview
+@Composable
+private fun ZoomableImageScreenPreview() {
+    ZoomableImageScreen(
+        imageRequest = ImageRequest.Builder(LocalContext.current)
+            .data(R.drawable.img_empty_chat_list)
+            .build(),
+        contentDescription = null,
+        modifier = Modifier.fillMaxSize(),
+        onBackClick = {},
+    )
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #255 

## Work Description ✏️
- 이미지 확대 및 축소가 가능한 화면 구현

## Screenshot 📸

https://github.com/user-attachments/assets/b77127a6-deaa-4350-bd62-208e27b44876

## To Reviewers 📢
- 이미지를 확대하는 화면을 구현했습니다! 
   `Modifier`의 `graphic`과 `transformable` 속성을 활용하여 화면 내 배치된 요소들의 속성을 가져와 다양한 연산을 진행하는 구조입니다! 
   조만간 노션에 정리글 올릴테니까 궁금해도 참아주세요~

- `ZoomableImageScreen`에서 이미지 매개변수를 `ImageRequest` 타입으로 설정했습니다. 이전 화면에서 로드한 이미지를 다시 로드할 필요가 없을 것 같아서 이렇게 구현해봤는데, 괜찮은지 판단 좀 부탁드릴게요!! 