### PR TITLE
[FEAT/#262] 채팅사진 등록 API 연결

### DIFF
--- a/core/util/src/main/java/com/napzak/market/util/android/Result.kt
+++ b/core/util/src/main/java/com/napzak/market/util/android/Result.kt
@@ -1,0 +1,13 @@
+package com.napzak.market.util.android
+
+import kotlin.coroutines.cancellation.CancellationException
+
+suspend fun <R> suspendRunCatching(block: suspend () -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (c: CancellationException) {
+        throw c
+    } catch (e: Exception) {
+        return Result.failure(e)
+    }
+}

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/datasource/PresignedUrlDataSource.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/datasource/PresignedUrlDataSource.kt
@@ -18,6 +18,10 @@ class PresignedUrlDataSource @Inject constructor(
         imageTitles: List<String>,
     ) = presignedUrlService.getProfilePresignedUrl(imageTitles).data
 
+    suspend fun getChatPresignedUrl(
+        imageTitles: List<String>,
+    ) = presignedUrlService.getChatPresignedUrl(imageTitles).data
+
     suspend fun putViaPresignedUrl(
         presignedUrl: String,
         imageUri: String,

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/dto/ChatPresignedUrlResponse.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/dto/ChatPresignedUrlResponse.kt
@@ -1,0 +1,10 @@
+package com.napzak.market.presigned_url.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChatPresignedUrlResponse(
+    @SerialName("chatPresignedUrls")
+    val presignedUrls: Map<String, String>,
+)

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/mapper/PresignedUrlMapper.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/mapper/PresignedUrlMapper.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.presigned_url.mapper
 
+import com.napzak.market.presigned_url.dto.ChatPresignedUrlResponse
 import com.napzak.market.presigned_url.dto.ProductPresignedUrlResponse
 import com.napzak.market.presigned_url.dto.ProfilePresignedUrlResponse
 import com.napzak.market.presigned_url.model.PresignedUrl
@@ -21,6 +22,17 @@ fun ProductPresignedUrlResponse.toDomain() = presignedUrls.map { (imageName, url
  * Map 형태의 데이터를 PresignedUrl List 형태로 변환
  */
 fun ProfilePresignedUrlResponse.toDomain() = presignedUrls.map { (imageName, url) ->
+    PresignedUrl(
+        imageName = imageName,
+        url = url,
+    )
+}
+
+/**
+ * To domain
+ * Map 형태의 데이터를 PresignedUrl List 형태로 변환
+ */
+fun ChatPresignedUrlResponse.toDomain() = presignedUrls.map { (imageName, url) ->
     PresignedUrl(
         imageName = imageName,
         url = url,

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepositoryImpl.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.napzak.market.presigned_url.repository
 import com.napzak.market.presigned_url.datasource.PresignedUrlDataSource
 import com.napzak.market.presigned_url.mapper.toDomain
 import com.napzak.market.presigned_url.model.PresignedUrl
+import com.napzak.market.util.android.suspendRunCatching
 import javax.inject.Inject
 
 class PresignedUrlRepositoryImpl @Inject constructor(
@@ -18,6 +19,12 @@ class PresignedUrlRepositoryImpl @Inject constructor(
         imageTitles: List<String>,
     ): Result<List<PresignedUrl>> = runCatching {
         presignedUrlDataSource.getProfilePresignedUrl(imageTitles = imageTitles).toDomain()
+    }
+
+    override suspend fun getChatPresignedUrls(
+        imageTitles: List<String>,
+    ): Result<List<PresignedUrl>> = suspendRunCatching {
+        presignedUrlDataSource.getChatPresignedUrl(imageTitles).toDomain()
     }
 
     override suspend fun putViaPresignedUrl(

--- a/data/presigned-url/src/main/java/com/napzak/market/presigned_url/service/PresignedUrlService.kt
+++ b/data/presigned-url/src/main/java/com/napzak/market/presigned_url/service/PresignedUrlService.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.presigned_url.service
 
+import com.napzak.market.presigned_url.dto.ChatPresignedUrlResponse
 import com.napzak.market.presigned_url.dto.ProductPresignedUrlResponse
 import com.napzak.market.presigned_url.dto.ProfilePresignedUrlResponse
 import com.napzak.market.remote.model.BaseResponse
@@ -21,6 +22,11 @@ interface PresignedUrlService {
     suspend fun getProfilePresignedUrl(
         @Query("profileImages") imageTitles: List<String>,
     ): BaseResponse<ProfilePresignedUrlResponse>
+
+    @GET("presigned-url/chat")
+    suspend fun getChatPresignedUrl(
+        @Query("chatImages") imageTitles: List<String>,
+    ): BaseResponse<ChatPresignedUrlResponse>
 
     @PUT
     suspend fun putViaPresignedUrl(

--- a/domain/presigned-url/build.gradle.kts
+++ b/domain/presigned-url/build.gradle.kts
@@ -3,5 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(projects.core.util)
     implementation(libs.javax.inject)
+    implementation(libs.coroutines.core)
 }

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/model/UploadImage.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/model/UploadImage.kt
@@ -1,0 +1,17 @@
+package com.napzak.market.presigned_url.model
+
+data class UploadImage(
+    val imageType: ImageType,
+    val uri: String,
+    val title: String = imageType.imageName,
+    val presignedUrl: String = "",
+) {
+    enum class ImageType(
+        val imageName: String = "",
+    ) {
+        PRODUCT,
+        COVER(imageName = "cover.jpg"),
+        PROFILE(imageName = "profile.jpg"),
+        CHAT
+    }
+}

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepository.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/repository/PresignedUrlRepository.kt
@@ -7,5 +7,7 @@ interface PresignedUrlRepository {
 
     suspend fun getProfilePresignedUrls(imageTitles: List<String>): Result<List<PresignedUrl>>
 
+    suspend fun getChatPresignedUrls(imageTitles: List<String>): Result<List<PresignedUrl>>
+
     suspend fun putViaPresignedUrl(presignedUrl: String, imageUri: String): Result<Unit>
 }

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
@@ -1,0 +1,51 @@
+package com.napzak.market.presigned_url.usecase
+
+import com.napzak.market.presigned_url.model.UploadImage
+import com.napzak.market.presigned_url.repository.PresignedUrlRepository
+import com.napzak.market.util.android.suspendRunCatching
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import javax.inject.Inject
+
+class UploadImagesUseCase @Inject constructor(
+    private val presignedUrlRepository: PresignedUrlRepository
+) {
+    suspend operator fun invoke(
+        images: List<UploadImage>
+    ): Result<Map<UploadImage.ImageType, String>> = suspendRunCatching {
+        val uploadImages = getPresignedUrls(images)
+        putImageOnS3(uploadImages)
+
+        buildMap {
+            uploadImages.forEach { image ->
+                put(image.imageType, image.presignedUrl)
+            }
+        }
+    }
+
+    private suspend fun getPresignedUrls(images: List<UploadImage>): List<UploadImage> {
+        val imageTitles = images.map { imageType -> imageType.title }
+        val presignedUrls = presignedUrlRepository.getProfilePresignedUrls(imageTitles).getOrThrow()
+        return presignedUrls.zip(images).map { (presignedUrl, image) ->
+            image.copy(presignedUrl = presignedUrl.url)
+        }
+    }
+
+    private suspend fun putImageOnS3(uploadImages: List<UploadImage>) = coroutineScope {
+        val semaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
+        uploadImages.map { image ->
+            async {
+                semaphore.withPermit {
+                    presignedUrlRepository.putViaPresignedUrl(image.presignedUrl, image.uri)
+                }.getOrThrow()
+            }
+        }.awaitAll()
+    }
+
+    companion object {
+        private const val MAX_CONCURRENT_REQUESTS = 10
+    }
+}

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
@@ -29,7 +29,21 @@ class UploadImagesUseCase @Inject constructor(
 
     private suspend fun getPresignedUrls(images: List<UploadImage>): List<UploadImage> {
         val imageTitles = images.map { imageType -> imageType.title }
-        val presignedUrls = presignedUrlRepository.getProfilePresignedUrls(imageTitles).getOrThrow()
+
+        val presignedUrls = when (images.first().imageType) {
+            ImageType.COVER, ImageType.PROFILE -> {
+                presignedUrlRepository.getProfilePresignedUrls(imageTitles)
+            }
+
+            ImageType.PRODUCT -> {
+                presignedUrlRepository.getProductPresignedUrls(imageTitles)
+            }
+
+            ImageType.CHAT -> {
+                presignedUrlRepository.getChatPresignedUrls(imageTitles)
+            }
+        }.getOrThrow()
+
         return presignedUrls.zip(images).map { (presignedUrl, image) ->
             image.copy(presignedUrl = presignedUrl.url)
         }

--- a/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
+++ b/domain/presigned-url/src/main/java/com/napzak/market/presigned_url/usecase/UploadImagesUseCase.kt
@@ -1,6 +1,7 @@
 package com.napzak.market.presigned_url.usecase
 
 import com.napzak.market.presigned_url.model.UploadImage
+import com.napzak.market.presigned_url.model.UploadImage.ImageType
 import com.napzak.market.presigned_url.repository.PresignedUrlRepository
 import com.napzak.market.util.android.suspendRunCatching
 import kotlinx.coroutines.async
@@ -11,11 +12,11 @@ import kotlinx.coroutines.sync.withPermit
 import javax.inject.Inject
 
 class UploadImagesUseCase @Inject constructor(
-    private val presignedUrlRepository: PresignedUrlRepository
+    private val presignedUrlRepository: PresignedUrlRepository,
 ) {
     suspend operator fun invoke(
-        images: List<UploadImage>
-    ): Result<Map<UploadImage.ImageType, String>> = suspendRunCatching {
+        images: List<UploadImage>,
+    ): Result<Map<ImageType, String>> = suspendRunCatching {
         val uploadImages = getPresignedUrls(images)
         putImageOnS3(uploadImages)
 


### PR DESCRIPTION
## Related issue 🛠
- closed #262 

## Work Description ✏️

- 코루틴 중단 시 던져지는 에러를 감지하기 위해 `suspendRunCatching`을 추가했습니다.

- 채팅화면에서 이미지 업로드를 시도할 때 필요한 presigned-url 받아오는 API 연결했습니다.

- 새로운 presign-url 관련 유즈케이스 `UploadImagesUseCase` 를 구현했습니다.
   - 이 유즈케이스는 모든 도메인의 presigned-url API를 관리하기 위해 만들었습니다.
   - `UploadImage` 모델의 목록을 파라미터로 받습니다.
      ```kotlin
      data class UploadImage(
         val imageType: ImageType,
         val uri: String,
         val title: String = imageType.imageName,
         val presignedUrl: String = "",
      ) {
         enum class ImageType(
            val imageName: String = "",
         ) {
            PRODUCT,
            COVER(imageName = "cover.jpg"),
            PROFILE(imageName = "profile.jpg"),
            CHAT
         }
      }
      ```
   - presigned url을 받아와 S3에 병렬적으로 업로드합니다.
   - 생성되는 코루틴 수를 10으로 제한했습니다. 이는 저희 앱에서 단일 작업으로 업로드 가능한 최대 이미지 수 입니다.

- 프로필 수정 화면에 `UploadImagesUseCase`을 적용했습니다.

## To Reviewers 📢
- 프로필 이미지 등록화면에서 s3에 이미지를 업로드하는 과정이 직렬적으로 이뤄지고 있어서, 이 과정을 병렬적으로 이뤄지도록 수정했습니다. 
- 물품등록의 뷰모델에서 동일한 병렬 작업을 수행 중인데, 물품 등록쪽 코드와 비교해서 미흡한 부분 있으면 댓글 달아주세요!  
- 이 PR이 머지된 이후에 등록화면에서도 이 유즈케이스를 사용하도록 리팩하면 좋을 것 같습니다😄 