### PR TITLE
[REFACTOR/#265] 메인화면 스택 관리 수정

### DIFF
--- a/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
@@ -73,10 +73,7 @@ internal fun HomeRoute(
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        with(viewModel) {
-            getBanners()
-            getHomeProducts()
-        }
+        viewModel.fetchHomeData()
     }
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {

--- a/feature/main/src/main/java/com/napzak/market/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainNavigator.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.napzak.market.chat.navigation.navigateToChatList
 import com.napzak.market.explore.navigation.navigateToExplore
+import com.napzak.market.home.navigation.Home
 import com.napzak.market.home.navigation.navigateToHome
 import com.napzak.market.mypage.navigation.navigateToMyPage
 import com.napzak.market.splash.navigation.Splash
@@ -42,7 +43,7 @@ class MainNavigator(
         if (tab != MainTab.REGISTER && isRegister) dismissRegisterDialog()
 
         val navOptions = navOptions {
-            navController.currentDestination?.route?.let {
+            navController.getBackStackEntry<Home>().destination.route?.let {
                 popUpTo(it) {
                     saveState = true
                 }
@@ -52,13 +53,13 @@ class MainNavigator(
         }
 
         when (tab) {
-            MainTab.HOME -> navController.navigateToHome(navOptions)
-            MainTab.EXPLORE -> navController.navigateToExplore()
+            MainTab.HOME -> navController.navigateToHome(navOptions = navOptions)
+            MainTab.EXPLORE -> navController.navigateToExplore(navOptions = navOptions)
             MainTab.REGISTER -> {
                 isRegister = isRegister.not()
             }
-            MainTab.CHAT -> navController.navigateToChatList()
-            MainTab.MY_PAGE -> navController.navigateToMyPage(navOptions)
+            MainTab.CHAT -> navController.navigateToChatList(navOptions = navOptions)
+            MainTab.MY_PAGE -> navController.navigateToMyPage(navOptions = navOptions)
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #265 

## Work Description ✏️

- 메인화면 내 화면 전환 버그를 수정했습니다.
   - 아이콘 더블 탭 오류
   - UI 리렌더링 문제
- 홈 뷰모델에서 api가 하나의 코투틴에서 동기적으로 호출되는 문제를 해결했습니다.

## To Reviewers 📢

메인화면 바텀바로 화면 전환을 할 때 아이콘을 두번 선택해야 하고, 전환되면 전체 화면이 다시 그려지는 문제를 발견했습니다!

파악한 바 의도하지 않는 UI 렌더링이 이뤄지는 이유는 다음과 같습니다:
1. A화면에서 B화면으로 이동할 때 PopUpToBuilder의 inclusive 설정이 false로 돼있어 A가 화면 스택에서 없어지지 않습니다.
2. B화면에서 A화면  아이콘을 탭하여 다시 전환하려고 할 때 launchSingleTop 설정으로 인해 전환되지 않습니다.
3. A화면 아이콘을 다시 탭하면 A화면 새로 스택에 쌓이고 UI가 다시 그려집니다.

```kotlin
// MainNavigator.kt
val navOptions = navOptions {
      navController.currentDestination?.route?.let { 
            popUpTo(it) {
                    // inclusive = false -> 기본 설정
                    saveState = true
            }
      }
      launchSingleTop = true
      restoreState = true
}
```

뒤로가기 버튼을 누르면 직전 화면으로 이동시키기 위해 위와 같은 방식으로 구현했지만, 정작 화면이 사라지지 않아 아이콘을 탭하여 이동할 때 오류가 발생하는 것이었습니다,,

`inclusive`을 `true`로 설정하게 되면 전환된 화면만 스택에 남기 때문에 뒤로가기 버튼을 누르면 그 화면에서 앱이 종료됩니다. 이 동작은 홈화면에서만 뒤로가기로 앱을 종료시킬 수 있어야 하는 앱의 기능과 맞지 않다고 판단했습니다.

따라서 일단 `navOption`의 `popUpTo`의 `route`를 `Home`으로 설정하여 어떤 탭으로 이동하든 뒤로가기를 누르면 홈화면으로 이동하도록 수정했습니다.

```kotlin
// MainNavigator.kt
val navOptions = navOptions {
      navController.getBackStackEntry<Home>().destination.route?.let {  // 무조건 Home까지 스택을 비움
            popUpTo(it) {
                    saveState = true
            }
      }
      launchSingleTop = true
      restoreState = true
}
```

혹시 더 나은 아이디어가 있다면 말해주세요~~ 