### PR TITLE
[UI/#267] 로딩 오버레이 구현

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/NapzakLoadingOverlay.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/NapzakLoadingOverlay.kt
@@ -1,0 +1,48 @@
+package com.napzak.market.designsystem.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.napzak.market.designsystem.R.raw.lottie_spinner
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.ui_util.ScreenPreview
+
+@Composable
+fun NapzakLoadingOverlay(
+    modifier: Modifier = Modifier,
+) {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(lottie_spinner))
+    val progress by animateLottieCompositionAsState(
+        composition = composition,
+        iterations = LottieConstants.IterateForever,
+    )
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        LottieAnimation(
+            composition = composition,
+            progress = { progress },
+            modifier = modifier.size(69.dp),
+        )
+    }
+}
+
+@ScreenPreview
+@Composable
+private fun NapzakLoadingOverlayPreview() {
+    NapzakMarketTheme {
+        NapzakLoadingOverlay()
+    }
+}

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
@@ -22,6 +22,7 @@ import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.ProductConditionType
 import com.napzak.market.common.type.TradeStatusType
 import com.napzak.market.common.type.TradeType
+import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
 import com.napzak.market.designsystem.component.dialog.NapzakDialogDefault
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
@@ -197,9 +198,8 @@ private fun ProductDetailScreen(
                 )
             }
 
-            is UiState.Failure -> {}
-            is UiState.Empty -> {}
-            is UiState.Loading -> {}
+            is UiState.Loading -> NapzakLoadingOverlay()
+            else -> {} // TODO: Empty, Failure 처리
         }
     }
 }

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
@@ -35,7 +35,7 @@ internal class ProductDetailViewModel @Inject constructor(
     private val productId: Long? = savedStateHandle.get<Long>(PRODUCT_ID_KEY)
 
     private val _productDetail: MutableStateFlow<UiState<ProductDetail>> =
-        MutableStateFlow(UiState.Empty)
+        MutableStateFlow(UiState.Loading)
     val productDetail = _productDetail.asStateFlow()
 
     // NOTE: 뷰모델이 처음 생성될 때 좋아요 로직이 불리는 것을 방지하기 위해 initialLoading을 사용한다.

--- a/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
@@ -7,9 +7,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,6 +27,7 @@ import coil.request.ImageRequest
 import com.napzak.market.banner.Banner
 import com.napzak.market.common.state.UiState
 import com.napzak.market.designsystem.R.string.heart_click_snackbar_message
+import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.textfield.SearchTextField
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
 import com.napzak.market.designsystem.component.toast.ToastType
@@ -137,7 +137,7 @@ private fun HomeScreen(
             )
 
             is UiState.Failure -> {}
-            is UiState.Loading -> {}
+            is UiState.Loading -> NapzakLoadingOverlay()
             is UiState.Empty -> {}
         }
     }
@@ -157,96 +157,112 @@ private fun HomeSuccessScreen(
     onMostInterestedBuyNavigate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scrollState = rememberScrollState()
     val context = LocalContext.current
 
-    Column(modifier = modifier.verticalScroll(scrollState)) {
-        SearchTextField(
-            text = "",
-            hint = stringResource(home_search_text_field_hint),
-            onTextChange = {},
-            onSearchClick = {},
-            onResetClick = {},
-            enabled = false,
-            readOnly = true,
-            modifier = Modifier
-                .noRippleClickable(onSearchTextFieldClick)
-                .padding(horizontal = 20.dp),
-        )
+    LazyColumn(modifier = modifier) {
+        item {
+            SearchTextField(
+                text = "",
+                hint = stringResource(home_search_text_field_hint),
+                onTextChange = {},
+                onSearchClick = {},
+                onResetClick = {},
+                enabled = false,
+                readOnly = true,
+                modifier = Modifier
+                    .noRippleClickable(onSearchTextFieldClick)
+                    .padding(horizontal = 20.dp),
+            )
+        }
 
-        banners[HomeBannerType.TOP]?.let { topBanners ->
-            HorizontalAutoScrolledImages(
-                images = topBanners.map { it.imageUrl }.toImmutableList(),
-                onImageClick = { index ->
-                    runCatching {
-                        context.openUrl(topBanners[index].linkUrl)
-                    }
+        item {
+            banners[HomeBannerType.TOP]?.let { topBanners ->
+                HorizontalAutoScrolledImages(
+                    images = topBanners.map { it.imageUrl }.toImmutableList(),
+                    onImageClick = { index ->
+                        runCatching {
+                            context.openUrl(topBanners[index].linkUrl)
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(360 / 216f)
+                        .padding(top = 20.dp),
+                )
+            }
+        }
+
+        item {
+            HorizontalScrollableProducts(
+                products = productRecommends,
+                title = stringResource(home_list_customized_title, nickname),
+                subTitle = stringResource(home_list_customized_sub_title, nickname),
+                onProductClick = onProductClick,
+                onLikeClick = { productId, isInterest ->
+                    onLikeButtonClick(productId, isInterest, HomeProductType.RECOMMEND)
                 },
+                modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 32.dp),
+            )
+        }
+
+        item {
+            banners[HomeBannerType.MIDDLE]?.let { banner ->
+                HomeSingleBanner(
+                    banner = banner.first(),
+                    modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 40.dp),
+                )
+            }
+        }
+
+        item {
+            VerticalGridProducts(
+                products = sellProducts,
+                title = stringResource(home_list_interested_sell_title),
+                subTitle = stringResource(home_list_interested_sell_sub_title),
+                onProductClick = onProductClick,
+                onLikeClick = { productId, isInterest ->
+                    onLikeButtonClick(productId, isInterest, HomeProductType.POPULAR_SELL)
+                },
+                onMoreClick = onMostInterestedSellNavigate,
+                modifier = Modifier
+                    .padding(top = 30.dp)
+                    .background(color = NapzakMarketTheme.colors.gray10)
+                    .padding(start = 20.dp, end = 20.dp, top = 32.dp, bottom = 20.dp),
+            )
+        }
+
+        item {
+            banners[HomeBannerType.BOTTOM]?.let { banner ->
+                HomeSingleBanner(
+                    banner = banner.first(),
+                    modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 40.dp),
+                )
+            }
+        }
+
+        item {
+            VerticalGridProducts(
+                products = buyProducts,
+                title = stringResource(home_list_interested_buy_title),
+                subTitle = stringResource(home_list_interested_buy_sub_title),
+                onProductClick = onProductClick,
+                onLikeClick = { productId, isInterest ->
+                    onLikeButtonClick(productId, isInterest, HomeProductType.POPULAR_BUY)
+                },
+                onMoreClick = onMostInterestedBuyNavigate,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 40.dp),
+            )
+        }
+
+
+        item {
+            Spacer(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(360 / 216f)
-                    .padding(top = 20.dp),
+                    .height(165.dp)
+                    .background(NapzakMarketTheme.colors.gray10)
             )
         }
-
-        HorizontalScrollableProducts(
-            products = productRecommends,
-            title = stringResource(home_list_customized_title, nickname),
-            subTitle = stringResource(home_list_customized_sub_title, nickname),
-            onProductClick = onProductClick,
-            onLikeClick = { productId, isInterest ->
-                onLikeButtonClick(productId, isInterest, HomeProductType.RECOMMEND)
-            },
-            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 32.dp),
-        )
-
-        banners[HomeBannerType.MIDDLE]?.let { banner ->
-            HomeSingleBanner(
-                banner = banner.first(),
-                modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 40.dp),
-            )
-        }
-
-        VerticalGridProducts(
-            products = sellProducts,
-            title = stringResource(home_list_interested_sell_title),
-            subTitle = stringResource(home_list_interested_sell_sub_title),
-            onProductClick = onProductClick,
-            onLikeClick = { productId, isInterest ->
-                onLikeButtonClick(productId, isInterest, HomeProductType.POPULAR_SELL)
-            },
-            onMoreClick = onMostInterestedSellNavigate,
-            modifier = Modifier
-                .padding(top = 30.dp)
-                .background(color = NapzakMarketTheme.colors.gray10)
-                .padding(start = 20.dp, end = 20.dp, top = 32.dp, bottom = 20.dp),
-        )
-
-        banners[HomeBannerType.BOTTOM]?.let { banner ->
-            HomeSingleBanner(
-                banner = banner.first(),
-                modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 40.dp),
-            )
-        }
-
-        VerticalGridProducts(
-            products = buyProducts,
-            title = stringResource(home_list_interested_buy_title),
-            subTitle = stringResource(home_list_interested_buy_sub_title),
-            onProductClick = onProductClick,
-            onLikeClick = { productId, isInterest ->
-                onLikeButtonClick(productId, isInterest, HomeProductType.POPULAR_BUY)
-            },
-            onMoreClick = onMostInterestedBuyNavigate,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 40.dp),
-        )
-
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(165.dp)
-                .background(NapzakMarketTheme.colors.gray10)
-        )
     }
 }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #267 

## Work Description ✏️
- 로딩 오버레이를 공통 컴포넌트로 추가했습니다.
- 홈화면과 물품 상세화면에 로딩 오버레이를 적용했습니다.
- 홈화면의 레이아웃을 `Column + ScrollState`에서 `LazyColumn`으로 수정했습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/35f89fb6-80d0-4237-9f45-c9bf0db3aed1

## Uncompleted Tasks 😅
- [ ] 앱 전체에 로딩UI 적용하기

## To Reviewers 📢
- 로딩 UI `NapzakLoadingOverlay`를 구현했습니다! 바텀시트 내 로딩을 제외하곤 모든 로딩은 화면 전체를 덮기로 의논했기 때문에 이 컴포넌트 사용하시면 됩니다!
- 그리고 각자 담당 화면에 로딩 화면 추가해주세요! 서버에게 요청을 보냈을 때 응답을 받아야 진행이 가능한 상황에 추가하면 됩니다~