### PR TITLE
[UI/#271] 이미지 확대 화면에 스크롤 기능 추가

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
@@ -1,13 +1,20 @@
 package com.napzak.market.designsystem.component.image
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -15,34 +22,41 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.napzak.market.designsystem.R.drawable.ic_arrow_left
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.ui_util.noRippleClickable
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun ZoomableImageScreen(
-    imageRequest: ImageRequest,
+    imageUrls: ImmutableList<String>,
+    initialPage: Int,
     contentDescription: String?,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var rootSize by remember { mutableStateOf(IntSize.Zero) }
+    val context = LocalContext.current
+    val pagerState = rememberPagerState(initialPage = initialPage) { imageUrls.size }
+    val zoomState = rememberZoomState()
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(color = NapzakMarketTheme.colors.black)
-            .onGloballyPositioned { rootSize = it.size },
+            .zIndex(1f)
+            .onGloballyPositioned { zoomState.parentLayoutSize = it.size },
         contentAlignment = Alignment.Center,
     ) {
         Icon(
@@ -51,82 +65,133 @@ fun ZoomableImageScreen(
             tint = NapzakMarketTheme.colors.white,
             modifier = Modifier
                 .align(Alignment.TopStart)
+                .zIndex(1f)
                 .padding(start = 20.dp, top = 34.dp)
                 .noRippleClickable(onClick = onBackClick),
         )
 
-        AsyncImage(
-            model = imageRequest,
-            contentDescription = contentDescription,
-            modifier = Modifier.zoomable(rootSize),
-        )
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize(),
+        ) { page ->
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(imageUrls[page])
+                    .crossfade(true)
+                    .build(),
+                contentDescription = contentDescription,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .zoomable(zoomState)
+            )
+        }
     }
 }
 
 // TODO: 안정화되면 ui_util로 이동
 private fun Modifier.zoomable(
-    parentLayoutSize: IntSize,
-    scaleRange: ClosedFloatingPointRange<Float> = 1f..5f,
-) = composed {
-    fun calculateConstrainedOffset(
-        currentOffset: Float,
-        offsetChange: Float,
-        scale: Float,
-        originalSize: Int,
-        parentSize: Int,
-        constraint: Float,
-    ): Float {
-        return when {
-            scale * originalSize < parentSize -> 0f
-            currentOffset + offsetChange !in -constraint..constraint -> {
-                currentOffset.coerceIn(-constraint, constraint)
-            }
+    zoomState: ZoomState,
+) = this
+    .onGloballyPositioned {
+        zoomState.originalIntSize = it.size
+    }
+    .pointerInput(Unit) {
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false)
 
-            else -> currentOffset + offsetChange * scale
+            do {
+                val event = awaitPointerEvent()
+                val zoomChange = event.calculateZoom()
+                val panChange = event.calculatePan()
+                var newOffset = Offset.Zero
+
+                zoomState.updateScale(zoomChange)
+                if (zoomState.scale > 1.0f) {
+                    newOffset = zoomState.getConstrainedOffset(panChange)
+                    event.changes.forEach { it.consume() }
+                }
+                zoomState.updateOffset(newOffset)
+            } while (event.changes.any { it.pressed })
         }
     }
+    .graphicsLayer(
+        scaleX = zoomState.scale,
+        scaleY = zoomState.scale,
+        translationX = zoomState.offset.x,
+        translationY = zoomState.offset.y,
+    )
 
-    var scale by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
-    var originalIntSize by remember { mutableStateOf(IntSize.Zero) }
 
-    val state = rememberTransformableState { zoomChange, offsetChange, _ ->
-        scale = (scale * zoomChange).coerceIn(scaleRange)
-        val offsetConstraints = Offset(
+@Composable
+private fun rememberZoomState(
+    scaleRange: ClosedFloatingPointRange<Float> = 1f..5f,
+) = remember { ZoomState(scaleRange) }
+
+@Stable
+private class ZoomState(
+    private val scaleRange: ClosedFloatingPointRange<Float>,
+) {
+    var scale by mutableFloatStateOf(1f)
+        private set
+    var offset by mutableStateOf(Offset.Zero)
+        private set
+
+    var parentLayoutSize by mutableStateOf(IntSize.Zero)
+    var originalIntSize by mutableStateOf(IntSize.Zero)
+
+    private val offsetConstraints = derivedStateOf {
+        Offset(
             x = (originalIntSize.width * scale - parentLayoutSize.width) / 2f,
             y = (originalIntSize.height * scale - parentLayoutSize.height) / 2f,
         )
+    }
+
+    fun updateScale(zoomChange: Float) {
+        this.scale = (this.scale * zoomChange).coerceIn(scaleRange)
+    }
+
+    fun updateOffset(newOffset: Offset) {
+        offset = newOffset
+    }
+
+    fun getConstrainedOffset(panChange: Offset): Offset {
+        fun calculateConstrainedOffset(
+            currentOffset: Float,
+            panChange: Float,
+            scale: Float,
+            originalSize: Int,
+            parentSize: Int,
+            constraint: Float,
+        ): Float {
+            return when {
+                scale * originalSize < parentSize -> 0f
+                currentOffset + panChange !in -constraint..constraint -> {
+                    currentOffset.coerceIn(-constraint, constraint)
+                }
+
+                else -> currentOffset + panChange * scale
+            }
+        }
 
         val offsetX = calculateConstrainedOffset(
             currentOffset = offset.x,
-            offsetChange = offsetChange.x,
+            panChange = panChange.x,
             scale = scale,
             originalSize = originalIntSize.width,
             parentSize = parentLayoutSize.width,
-            constraint = offsetConstraints.x,
+            constraint = offsetConstraints.value.x,
         )
 
         val offsetY = calculateConstrainedOffset(
             currentOffset = offset.y,
-            offsetChange = offsetChange.y,
+            panChange = panChange.y,
             scale = scale,
             originalSize = originalIntSize.height,
             parentSize = parentLayoutSize.height,
-            constraint = offsetConstraints.y,
+            constraint = offsetConstraints.value.y,
         )
 
-        offset = Offset(x = offsetX, y = offsetY)
+        return Offset(x = offsetX, y = offsetY)
     }
-
-    this
-        .onGloballyPositioned {
-            originalIntSize = it.size
-        }
-        .graphicsLayer(
-            scaleX = scale,
-            scaleY = scale,
-            translationX = offset.x,
-            translationY = offset.y,
-        )
-        .transformable(state = state)
 }

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
@@ -59,16 +60,21 @@ fun ZoomableImageScreen(
             .onGloballyPositioned { zoomState.parentLayoutSize = it.size },
         contentAlignment = Alignment.Center,
     ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(ic_arrow_left),
-            contentDescription = null,
-            tint = NapzakMarketTheme.colors.white,
+        Box(
             modifier = Modifier
+                .padding(start = 15.dp, top = 26.dp)
+                .size(24.dp)
                 .align(Alignment.TopStart)
                 .zIndex(1f)
-                .padding(start = 20.dp, top = 34.dp)
                 .noRippleClickable(onClick = onBackClick),
-        )
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(ic_arrow_left),
+                contentDescription = null,
+                tint = NapzakMarketTheme.colors.white,
+            )
+        }
 
         HorizontalPager(
             state = pagerState,

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.detail
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
@@ -218,6 +219,10 @@ private fun SuccessScreen(
     var selectedImageIndex: Int? by remember { mutableStateOf(null) }
     val imageUrls = remember(productPhotos) {
         productPhotos.map { it.photoUrl }.toImmutableList()
+    }
+
+    BackHandler(selectedImageIndex != null) {
+        selectedImageIndex = null
     }
 
     selectedImageIndex?.let {

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
@@ -25,6 +25,7 @@ import com.napzak.market.common.type.TradeType
 import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
 import com.napzak.market.designsystem.component.dialog.NapzakDialogDefault
+import com.napzak.market.designsystem.component.image.ZoomableImageScreen
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
 import com.napzak.market.designsystem.component.toast.ToastType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -214,12 +215,27 @@ private fun SuccessScreen(
     onMarketClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var selectedImageIndex: Int? by remember { mutableStateOf(null) }
+    val imageUrls = remember(productPhotos) {
+        productPhotos.map { it.photoUrl }.toImmutableList()
+    }
+
+    selectedImageIndex?.let {
+        ZoomableImageScreen(
+            imageUrls = imageUrls,
+            initialPage = it,
+            contentDescription = productDetail.productName,
+            onBackClick = { selectedImageIndex = null },
+        )
+    }
+
     LazyColumn(modifier = modifier) {
         item {
             ProductImageGroup(
-                imageUrls = productPhotos.map { it.photoUrl }.toImmutableList(),
+                imageUrls = imageUrls,
                 contentDescription = productDetail.productName,
                 tradeStatusType = tradeStatus,
+                onClick = { selectedImageIndex = it },
             )
 
             with(productDetail) {

--- a/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductImageGroup.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductImageGroup.kt
@@ -32,6 +32,7 @@ import com.napzak.market.feature.detail.R.drawable.ic_product_buy_complete_large
 import com.napzak.market.feature.detail.R.drawable.ic_product_reservation_large
 import com.napzak.market.feature.detail.R.drawable.ic_product_sell_complete_large
 import com.napzak.market.feature.detail.R.string.detail_product_image_indicator
+import com.napzak.market.ui_util.noRippleClickable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -43,6 +44,7 @@ internal fun ProductImageGroup(
     contentDescription: String,
     tradeStatusType: TradeStatusType,
     modifier: Modifier = Modifier,
+    onClick: (Int) -> Unit,
 ) {
     val context = LocalContext.current
     val pagerState = rememberPagerState(
@@ -69,7 +71,9 @@ internal fun ProductImageGroup(
                     .build(),
                 contentDescription = contentDescription,
                 contentScale = ContentScale.FillBounds,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .noRippleClickable { onClick(currentPage) }
             )
         }
 
@@ -149,6 +153,7 @@ private fun ProductImageGroupPreview() {
             ).toImmutableList(),
             contentDescription = "",
             tradeStatusType = TradeStatusType.BEFORE_TRADE,
+            onClick = {},
         )
     }
 }
@@ -165,6 +170,7 @@ private fun ReservedProductImageGroup() {
             ).toImmutableList(),
             contentDescription = "",
             tradeStatusType = TradeStatusType.RESERVED,
+            onClick = {},
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #271 

## Work Description ✏️

이 PR에서는 이미지 확대 화면을 대폭 수정했습니다!
- 매개변수를 단일 imageRequest에서 imageUrl 목록으로 변경했습니다
- Pager API를 사용하여 이미지 간 탐색을 구현했습니다.
- 이미지의 스케일과 오프셋을 다루기 위한 수정자 속성을 Transformable에서 하위 레벨 포인터 API인 pointerInput으로 변경했습니다.
   
   > `transformable`과 `nestedScroll`을 잘 조합해보려고 노력했지만, `transformable`이 붙어있는 `AsyncImage`에 어떤 설정을 하더라도 스크롤이 부모 레이아웃인 `Pager`로 전파되지가 않더라고요..
   >
   > 따라서 low-level 터치 이벤트 API인 `pointerInput`을 사용하여 포인터 두 개를 감지하고 명시적으로 소비하도록 구현했습니다! 결과는 스샷에서 보실 수 있습니다!

- 이미지의 스케일과 오프셋을 관리하는 상태 홀더 클래스를 구현했습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/28856352-1348-48d0-b199-62194006bf80

## Uncompleted Tasks 😅
- [ ] Android 15의 상태바 이슈 해결해야 합니다!

## To Reviewers 📢
- 확대 기능 완!
- `ZoomableImageScreen`의 `AsyncImage`가 전체 너비를 차지하도록 구현되어 있습니다! 
  
   허나 지금 상태에선 이미지의 높이가 화면 높이보다 길고, 이미지의 너비가 화면 너비보다 작으면 이미지의 상단과 하단이 잘리는 문제가 발생할 수 있습니다..!  위아래로 길쭉한 이미지를 넣는 사용자는 없을 것 같은데, 혹시라도 더 나은 구현 방식이 떠올랐다면 말해주세요!!!