### PR TITLE
[UI/#285] 구해요/팔아요 로딩 화면 추가

### DIFF
--- a/feature/registration/src/main/java/com/napzak/market/registration/purchase/PurchaseRegistrationScreen.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/purchase/PurchaseRegistrationScreen.kt
@@ -1,5 +1,7 @@
 package com.napzak.market.registration.purchase
 
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -24,7 +26,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.TradeType
+import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.button.NapzakButton
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.registration.R.string.purchase
@@ -57,6 +61,7 @@ fun PurchaseRegistrationRoute(
     val registrationUiState by viewModel.registrationUiState.collectAsStateWithLifecycle()
     val purchaseUiState by viewModel.purchaseUiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
@@ -66,6 +71,12 @@ fun PurchaseRegistrationRoute(
                 }
             }
     }
+
+    BackHandler(registrationUiState.loadState !is UiState.Loading) {
+        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.onBackPressed()
+    }
+
+    if (registrationUiState.loadState is UiState.Loading) NapzakLoadingOverlay()
 
     PurchaseRegistrationScreen(
         registrationUiState = registrationUiState,

--- a/feature/registration/src/main/java/com/napzak/market/registration/purchase/PurchaseRegistrationScreen.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/purchase/PurchaseRegistrationScreen.kt
@@ -28,8 +28,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.TradeType
-import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.button.NapzakButton
+import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.registration.R.string.purchase
 import com.napzak.market.feature.registration.R.string.purchase_price

--- a/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationScreen.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationScreen.kt
@@ -30,8 +30,8 @@ import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.ProductConditionType
 import com.napzak.market.common.type.TradeType
-import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.button.NapzakButton
+import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.registration.R.string.product_condition
 import com.napzak.market.feature.registration.R.string.register

--- a/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationScreen.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationScreen.kt
@@ -1,5 +1,7 @@
 package com.napzak.market.registration.sale
 
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -25,8 +27,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.ProductConditionType
 import com.napzak.market.common.type.TradeType
+import com.napzak.market.designsystem.component.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.button.NapzakButton
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.registration.R.string.product_condition
@@ -62,6 +66,7 @@ fun SaleRegistrationRoute(
     val registrationUiState by viewModel.registrationUiState.collectAsStateWithLifecycle()
     val saleUiState by viewModel.saleUiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
@@ -71,6 +76,12 @@ fun SaleRegistrationRoute(
                 }
             }
     }
+
+    BackHandler(registrationUiState.loadState !is UiState.Loading) {
+        onBackPressedDispatcherOwner?.onBackPressedDispatcher?.onBackPressed()
+    }
+
+    if (registrationUiState.loadState is UiState.Loading) NapzakLoadingOverlay()
 
     SaleRegistrationScreen(
         registrationUiState = registrationUiState,


### PR DESCRIPTION
## Related issue 🛠
- closed #285 

## Work Description ✏️
- 구해요/팔아요 등록 시 로딩화면을 추가했습니다.
- `LocalOnBackPressedDispatcherOwner`로 loadState가 Loading이 아닐 경우에만 뒤로가기가 활성화되도록 했슴다.

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
별거업내요 리뷰 부탁요 ㅋㅎ