### PR TITLE
[UI/#287] 온보딩 장르 검색 로딩뷰 적용

### DIFF
--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/GenreScreen.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/GenreScreen.kt
@@ -194,6 +194,7 @@ fun GenreScreen(
                 GenreGridList(
                     genres = uiState.genres,
                     onGenreClick = onGenreClick,
+                    isLoading = uiState.isLoading,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 20.dp),

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/component/GenreGridList.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/component/GenreGridList.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.napzak.market.common.state.UiState
+import com.napzak.market.designsystem.component.loading.NapzakLoadingSpinnerOverlay
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.onboarding.genre.model.GenreUiModel
 
@@ -27,6 +29,7 @@ import com.napzak.market.onboarding.genre.model.GenreUiModel
 fun GenreGridList(
     genres: List<GenreUiModel>,
     onGenreClick: (GenreUiModel) -> Unit,
+    isLoading: UiState<List<GenreUiModel>>,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -63,6 +66,12 @@ fun GenreGridList(
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Spacer(modifier = Modifier.height(100.dp))
             }
+        }
+
+        if (isLoading is UiState.Loading) {
+            NapzakLoadingSpinnerOverlay(
+                modifier = Modifier.align(Alignment.Center)
+            )
         }
 
         Box(

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/model/GenreUiState.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/genre/model/GenreUiState.kt
@@ -1,8 +1,11 @@
 package com.napzak.market.onboarding.genre.model
 
+import com.napzak.market.common.state.UiState
+
 data class GenreUiState(
     val genres: List<GenreUiModel> = emptyList(),
     val selectedGenres: List<GenreUiModel> = emptyList(),
+    val isLoading: UiState<List<GenreUiModel>> = UiState.Success(emptyList()),
     val searchText: String = "",
 ) {
     val isCompleted: Boolean


### PR DESCRIPTION
## Related issue 🛠
- closed #287 

## Work Description ✏️
- 온보딩 장르 검색 그리드 리스트에 로딩뷰 적용

## Screenshot 📸
제가 여러번의 테스트를 해보았는데 데이터들이 빨리 내려오는 편이랑 로딩 상태를 확인하기가 어렵습니다..!
로딩 상태가 아니라 true로 두고 테스트를 해보았을 때는 스피너 뒤로 리스트 뷰가 보이기는 하지만(이미 로딩을 마친 상태이기 때문에) 
문제 없이 스피너 노출되는 거 확인했습니다!

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢