### PR TITLE
[MOD/#326] 반값 택배 최소 금액 수정

### DIFF
--- a/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationViewModel.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/sale/SaleRegistrationViewModel.kt
@@ -105,7 +105,7 @@ class SaleRegistrationViewModel @Inject constructor(
         return !(registrationState.imageUris.isEmpty() || registrationState.genre == null || registrationState.title.isEmpty()
                 || registrationState.description.isEmpty() || registrationState.price.isEmpty() || saleState.condition == null
                 || saleState.isShippingFeeIncluded == null || (saleState.isShippingFeeIncluded == false && (saleState.normalShippingFee.isEmpty() && saleState.halfShippingFee.isEmpty()))
-                || (saleState.isNormalShippingChecked && saleState.normalShippingFee.priceToNumericTransformation() < 100) || (saleState.isHalfShippingChecked && saleState.halfShippingFee.isEmpty()))
+                || (saleState.isNormalShippingChecked && saleState.normalShippingFee.priceToNumericTransformation() < 100) || (saleState.isHalfShippingChecked && saleState.halfShippingFee.priceToNumericTransformation() < 100))
     }
 
     override suspend fun uploadProduct(presignedUrls: List<PresignedUrl>) {

--- a/feature/registration/src/main/res/values/string.xml
+++ b/feature/registration/src/main/res/values/string.xml
@@ -30,7 +30,7 @@
     <string name="normal_shipping">일반 택배</string>
     <string name="normal_shipping_hint">100~30,000</string>
     <string name="half_priced_shipping">반값/알뜰 택배</string>
-    <string name="half_priced_shipping_hint">0~5,000</string>
+    <string name="half_priced_shipping_hint">100~5,000</string>
 
     <!-- Purchase Components   -->
     <string name="purchase">구해요</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #326

## Work Description ✏️
- 디코 스레드에 올라온 것처럼 일관성 유지 + 0원일 경우 UI에 뜨지 않던 문제를 해결하기 위해 반값 택배 최소 금액을 100원으로 수정했습니다!

## Screenshot 📸
<img width="686" height="148" alt="스크린샷 2025-08-19 오전 12 52 41" src="https://github.com/user-attachments/assets/ac18b49a-c41a-4502-aa0e-196f3e29821e" />


## Uncompleted Tasks 😅

## To Reviewers 📢