### PR TITLE
[MOD/#334] 배송비 관련 문자열 수정

### DIFF
--- a/feature/detail/src/main/res/values/strings.xml
+++ b/feature/detail/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="detail_product_title_product_condition">상품 상태</string>
 
     <string name="detail_product_title_delivery">배송비</string>
-    <string name="detail_product_delivery_included">배송비 포함</string>
+    <string name="detail_product_delivery_included">포함</string>
     <string name="detail_product_delivery_normal">일반 택배 %s원</string>
     <string name="detail_product_delivery_half">반값/알뜰 택배 %s원</string>
 


### PR DESCRIPTION
## Related issue 🛠
- closed #334 

## Work Description ✏️
QA시트에 적혀 있듯이 "배송비 포함"에서 "포함"으로 문자열 리소스 수정했습니다.

## Screenshot 📸

<img width="300" alt="Screenshot_20250823_122156" src="https://github.com/user-attachments/assets/8b8c485f-e411-40f0-9930-c587b11b861f" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
별거 없어요 ㅋ