### PR TITLE
[HOTFIX/#333] 웹뷰 로그인 안정화 및 JWT role 기반 자동로그인/온보딩 가드 도입

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 val localProps = Properties().apply {
     val f = File(rootDir, "local.properties")
-    if (f.exists()) load(f.inputStream())
+    if (f.exists()) f.inputStream().use { load(it) }
 }
 
 val kakaoNativeKey: String =

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
             isDebuggable = true
         }
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            isMinifyEnabled = false
+            isShrinkResources = false
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,13 +46,12 @@
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
                 <data
                     android:scheme="${kakaoScheme}"
                     android:host="oauth" />

--- a/core/ui_util/src/main/java/com/napzak/market/ui_util/FindActivity.kt
+++ b/core/ui_util/src/main/java/com/napzak/market/ui_util/FindActivity.kt
@@ -1,0 +1,14 @@
+package com.napzak.market.ui_util
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+fun Context.findActivity(): Activity? {
+    var c = this
+    while (c is ContextWrapper) {
+        if (c is Activity) return c
+        c = c.baseContext
+    }
+    return null
+}

--- a/core/ui_util/src/main/java/com/napzak/market/ui_util/JwtInspector.kt
+++ b/core/ui_util/src/main/java/com/napzak/market/ui_util/JwtInspector.kt
@@ -1,0 +1,13 @@
+package com.napzak.market.ui_util
+
+import android.util.Base64
+import org.json.JSONObject
+
+object JwtInspector {
+    fun extractRoleString(token: String?): String? = runCatching {
+        if (token.isNullOrBlank()) return null
+        val payload = token.split(".").getOrNull(1) ?: return null
+        val json = String(Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP))
+        JSONObject(json).optString("role", null)
+    }.getOrNull()
+}

--- a/core/util/src/main/java/com/napzak/market/util/android/TokenProvider.kt
+++ b/core/util/src/main/java/com/napzak/market/util/android/TokenProvider.kt
@@ -7,5 +7,6 @@ interface TokenProvider {
     suspend fun updateAccessToken(token: String?)
     suspend fun updateRefreshToken(token: String?)
     suspend fun reissueAccessToken(): String?
+    suspend fun getAccessTokenRole(): String?
     suspend fun clearTokens()
 }

--- a/data/store/build.gradle.kts
+++ b/data/store/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.domain.store)
     implementation(projects.data.local)
     implementation(projects.core.util)
+    implementation(projects.core.uiUtil)
 
     implementation(libs.timber)
 }

--- a/data/store/src/main/java/com/napzak/market/store/di/RepositoryModule.kt
+++ b/data/store/src/main/java/com/napzak/market/store/di/RepositoryModule.kt
@@ -39,4 +39,9 @@ abstract class RepositoryModule {
     abstract fun bindTokenProvider(
         impl: TokenProviderImpl
     ): TokenProvider
+
+    @Binds
+    abstract fun bindAuthRepository(
+        impl: AuthRepositoryImpl
+    ): AuthRepository
 }

--- a/data/store/src/main/java/com/napzak/market/store/di/RepositoryModule.kt
+++ b/data/store/src/main/java/com/napzak/market/store/di/RepositoryModule.kt
@@ -39,9 +39,4 @@ abstract class RepositoryModule {
     abstract fun bindTokenProvider(
         impl: TokenProviderImpl
     ): TokenProvider
-
-    @Binds
-    abstract fun bindAuthRepository(
-        impl: AuthRepositoryImpl
-    ): AuthRepository
 }

--- a/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
@@ -12,6 +12,7 @@ class CheckAutoLoginUseCase @Inject constructor(
         require(!access.isNullOrBlank()) { "No access token" }
 
         val role = tokenProvider.getAccessTokenRole()
+            ?.removePrefix("ROLE_")
             ?.uppercase()
 
         if (role == "STORE") {

--- a/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
@@ -5,15 +5,20 @@ import com.napzak.market.util.android.TokenProvider
 import javax.inject.Inject
 
 class CheckAutoLoginUseCase @Inject constructor(
-    private val authRepository: AuthRepository,
     private val tokenProvider: TokenProvider,
 ) {
     suspend operator fun invoke(): Result<Unit> = runCatching {
-        val refreshToken = tokenProvider.getRefreshToken()
-            ?: throw IllegalStateException("refreshToken 없음")
+        val access = tokenProvider.getAccessToken()
+        require(!access.isNullOrBlank()) { "No access token" }
 
-        val newAccessToken = authRepository.reissue(refreshToken)
+        val role = tokenProvider.getAccessTokenRole()
+            ?.uppercase()
 
-        tokenProvider.updateAccessToken(newAccessToken)
+        if (role == "STORE") {
+            Unit
+        } else {
+            tokenProvider.clearTokens()
+            error("Not active role: $role")
+        }
     }
 }

--- a/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/usecase/CheckAutoLoginUseCase.kt
@@ -1,6 +1,5 @@
 package com.napzak.market.store.usecase
 
-import com.napzak.market.store.repository.AuthRepository
 import com.napzak.market.util.android.TokenProvider
 import javax.inject.Inject
 

--- a/domain/store/src/main/java/com/napzak/market/store/usecase/SaveTokenUseCase.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/usecase/SaveTokenUseCase.kt
@@ -1,0 +1,19 @@
+package com.napzak.market.store.usecase
+
+import com.napzak.market.util.android.TokenProvider
+import javax.inject.Inject
+
+class SaveTokensUseCase @Inject constructor(
+    private val tokenProvider: TokenProvider,
+) {
+    suspend operator fun invoke(
+        accessToken: String,
+        refreshToken: String? = null,
+    ): Result<Unit> = runCatching {
+        if (refreshToken == null) {
+            tokenProvider.setTokens(accessToken, tokenProvider.getRefreshToken() ?: "")
+        } else {
+            tokenProvider.setTokens(accessToken, refreshToken)
+        }
+    }
+}

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.common)
     implementation(projects.core.util)
+    implementation(projects.core.uiUtil)
     implementation(projects.domain.store)
     implementation(projects.feature.onboarding)
     implementation(projects.feature.home)

--- a/feature/login/src/main/java/com/napzak/market/login/LoginKakaoLauncher.kt
+++ b/feature/login/src/main/java/com/napzak/market/login/LoginKakaoLauncher.kt
@@ -1,35 +1,59 @@
 package com.napzak.market.login
 
-import android.content.Context
+import android.app.Activity
+import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 
 class LoginKakaoLauncher(
-    private val context: Context,
+    private val activityProvider: () -> Activity?,
     private val onTokenReceived: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
+    private val onGuide: (Guide) -> Unit = {},
 ) {
+
     fun startKakaoLogin() {
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-                if (token != null) {
-                    onTokenReceived(token.accessToken)
-                } else if (error != null && error !is ClientError) {
-                    loginWithKakaoAccount()
+        val activity = activityProvider() ?: run {
+            onError(IllegalStateException("Activity is null")); return
+        }
+        val kakao = UserApiClient.instance
+
+        if (kakao.isKakaoTalkLoginAvailable(activity)) {
+            kakao.loginWithKakaoTalk(activity) { token, error ->
+                when {
+                    token != null -> onToken(token)
+                    error is ClientError && error.reason == ClientErrorCause.Cancelled -> {
+                        onError(error)
+                    }
+
+                    else -> {
+                        loginWithKakaoAccount(activity)
+                    }
                 }
             }
         } else {
-            loginWithKakaoAccount()
+            loginWithKakaoAccount(activity)
         }
     }
 
-    private fun loginWithKakaoAccount() {
-        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-            if (token != null) {
-                onTokenReceived(token.accessToken)
-            } else if (error != null) {
-                onError(error)
+    private fun loginWithKakaoAccount(activity: Activity) {
+        UserApiClient.instance.loginWithKakaoAccount(activity) { token, error ->
+            when {
+                token != null -> onToken(token)
+                error is ClientError && error.reason == ClientErrorCause.NotSupported -> {
+                    onGuide(Guide.EnableChromeOrInstallKakaoTalk)
+                }
+
+                error != null -> onError(error)
+                else -> onError(IllegalStateException("KakaoAccount: token/error both null"))
             }
         }
     }
+
+    private fun onToken(token: OAuthToken) {
+        onTokenReceived(token.accessToken)
+    }
+
+    enum class Guide { EnableChromeOrInstallKakaoTalk }
 }

--- a/feature/login/src/main/java/com/napzak/market/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/napzak/market/login/LoginScreen.kt
@@ -2,16 +2,14 @@ package com.napzak.market.login
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -26,6 +24,7 @@ import com.napzak.market.designsystem.R.raw.lottie_login
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.login.component.KakaoLoginButton
 import com.napzak.market.login.model.LoginFlowRoute
+import com.napzak.market.ui_util.findActivity
 
 @Composable
 fun LoginRoute(
@@ -36,20 +35,24 @@ fun LoginRoute(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
 
+    val kakaoLauncher = remember {
+        LoginKakaoLauncher(
+            activityProvider = { context.findActivity() },
+            onTokenReceived = { accessToken -> viewModel.loginWithKakao(accessToken) },
+            onError = { t -> viewModel.onKakaoLoginFailed(t) },
+            onGuide = { viewModel.onRequireBrowserGuide() },
+        )
+    }
+
     LaunchedEffect(uiState.route) {
-        uiState.route?.let { onRouteChanged(it) }
+        uiState.route?.let {
+            onRouteChanged(it)
+            viewModel.consumeRoute()
+        }
     }
 
     LoginScreen(
-        onKakaoLoginClick = {
-            LoginKakaoLauncher(
-                context = context,
-                onTokenReceived = { token -> viewModel.loginWithKakao(token) },
-                onError = {
-                    //TODO 추후 구현
-                }
-            ).startKakaoLogin()
-        },
+        onKakaoLoginClick = { kakaoLauncher.startKakaoLogin() },
         modifier = modifier,
     )
 }

--- a/feature/login/src/main/java/com/napzak/market/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/napzak/market/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.napzak.market.login.model.LoginFlowRoute
 import com.napzak.market.login.model.LoginUiState
+import com.napzak.market.store.usecase.SaveTokensUseCase
 import com.napzak.market.store.usecase.SetKakaoLoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,35 +17,52 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val setKakaoLoginUseCase: SetKakaoLoginUseCase,
+    private val saveTokensUseCase: SaveTokensUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
     fun loginWithKakao(token: String) {
+        if (_uiState.value.loading) return
+
         viewModelScope.launch {
             _uiState.update { it.copy(loading = true) }
 
             setKakaoLoginUseCase(token)
                 .onSuccess { response ->
-                    when (response.role) {
-                        "ONBOARDING","WITHDRAWN" -> {
-                            _uiState.update { it.copy(route = LoginFlowRoute.Terms) }
-                        }
-
-                        "STORE" -> {
-                            _uiState.update { it.copy(route = LoginFlowRoute.Main) }
-                        }
-
-                        else -> {
-                            _uiState.update { it.copy(route = null) }
-                        }
+                    runCatching {
+                        saveTokensUseCase(
+                            accessToken = response.accessToken,
+                            refreshToken = response.refreshToken,
+                        )
                     }
+
+                    val nextRoute = when (response.role) {
+                        "ONBOARDING", "WITHDRAWN" -> LoginFlowRoute.Terms
+                        "STORE" -> LoginFlowRoute.Main
+                        else -> null
+                    }
+
+                    _uiState.update { it.copy(loading = false, route = nextRoute) }
                 }
                 .onFailure { e ->
-                    // TODO: 추후 구현
                     _uiState.update { it.copy(loading = false) }
                 }
         }
+    }
+
+    fun consumeRoute() {
+        if (_uiState.value.route != null) {
+            _uiState.update { it.copy(route = null) }
+        }
+    }
+
+    fun onRequireBrowserGuide() {
+        //TODO 추후 안내 메세지 추가
+    }
+
+    fun onKakaoLoginFailed(t: Throwable) {
+        _uiState.update { it.copy(loading = false) }
     }
 }

--- a/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/napzak/market/main/MainScreen.kt
@@ -188,7 +188,7 @@ private fun MainNavHost(
                     }
                 )
             },
-            onNavigateToOnboarding = {
+            onNavigateToLogin = {
                 navigator.navController.navigateToLogin(
                     navOptions {
                         popUpTo<Splash> { inclusive = true }

--- a/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
@@ -29,11 +29,10 @@ import kotlinx.coroutines.delay
 @Composable
 internal fun SplashRoute(
     onNavigateToMain: () -> Unit,
-    onNavigateToOnboarding: () -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SplashViewModel = hiltViewModel(),
 ) {
-    var isSuccess by remember { mutableStateOf(false) }
     val view = LocalView.current
 
     DisposableEffect(Unit) {
@@ -45,15 +44,14 @@ internal fun SplashRoute(
         }
     }
 
-    LaunchedEffect(Unit) {
-        val result = viewModel.tryAutoLogin()
-        isSuccess = result.isSuccess
+    val navigated = remember { mutableStateOf(false) }
 
+    LaunchedEffect(Unit) {
+        val success = viewModel.tryAutoLogin().isSuccess
         delay(2500)
-        if (isSuccess) {
-            onNavigateToMain()
-        } else {
-            onNavigateToOnboarding()
+        if (!navigated.value) {
+            navigated.value = true
+            if (success) onNavigateToMain() else onNavigateToLogin()
         }
     }
 

--- a/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector

--- a/feature/splash/src/main/java/com/napzak/market/splash/navigation/SplashNavigator.kt
+++ b/feature/splash/src/main/java/com/napzak/market/splash/navigation/SplashNavigator.kt
@@ -9,13 +9,13 @@ import kotlinx.serialization.Serializable
 
 fun NavGraphBuilder.splashGraph(
     onNavigateToMain: () -> Unit,
-    onNavigateToOnboarding: () -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     composable<Splash> {
         SplashRoute(
             onNavigateToMain = onNavigateToMain,
-            onNavigateToOnboarding = onNavigateToOnboarding,
+            onNavigateToLogin = onNavigateToLogin,
             modifier = modifier,
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #333 

## Work Description ✏️
- 웹뷰 로그인 안정화
- JWT role 기반 가드 도입
- 자동로그인 단순화
- 네비게이션 정리(SplashRoute)


## Screenshot 📸

https://github.com/user-attachments/assets/efb97056-1e74-4b33-9fa8-3020a1d1076d


https://github.com/user-attachments/assets/fd59ddc6-ff42-4fb0-984b-04656b986dfb



## Uncompleted Tasks 😅
- 자동로그인이 정상 작동하기는 하지만 풀리는 경우가 반드시 1번은 발생함
-> 해당 문제는 원인을 파악해서 빠른 시일내에 해결하겠습니다..!

## To Reviewers 📢
[문제사항]
- 웹 경로 로그인 시 로그인이 되지 않는 문제
- 웹/앱 경로 모두에서 로그인은 되지만 온보딩(약관/닉네임) 미완료 상태로 재진입 시 홈으로 진입하거나 500이 발생하던 문제
- 서버가 ONBOARDING 유저에게도 토큰(재발급 포함)을 내려주는 구조라 “토큰 존재 여부”만으로는 라우팅을 결정할 수 없는 문제

[해결]
1. 웹뷰 로그인 안정화
- WebView/외부 브라우저 콜백을 통일된 진입점(Splash)으로 라우팅.
- 로그인 완료 후 앱 복귀 시 기존 흐름과 동일하게 자동 로그인 가드가 동작하도록 연결.

2. JWT role 기반 가드 도입
- TokenProvider에 getAccessTokenRole(): String? 추가(문자열 반환).
- JwtInspector 추가: access JWT payload에서 "role" 추출.
- 시작 가드(Splash): role == "STORE"일 때만 Main, 그 외(ONBOARDING/WITHDRAWN/파싱 실패)는 토큰 즉시 clear → Login.
- 재발급 가드: 재발급된 토큰의 role이 "STORE"가 아니면 세션 제거(홈 진입 차단).

3. 자동로그인 단순화
- CheckAutoLoginUseCase: access 존재 + role=="STORE" 만 성공으로 간주.
- refresh 토큰은 재발급 단계에서만 사용(자동로그인 판정에서 요구하지 않음).

4. 네비게이션 정리(SplashRoute)
- tryAutoLogin().isSuccess 기준으로 2.5s 후 Main 또는 Login 이동.
- 실패 시 온보딩이 아닌 Login으로 명확히 분기.

5. 동시성/안정성
- TokenProviderImpl에 Mutex.withLock 적용: 동시 재발급/경합 방지.
- withLock 내부 반환은 라벨 리턴으로 컴파일 안정화.