### PR TITLE
[FEAT/#341] 스로틀 버튼 구현 및 적용

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakThrottleButton.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/button/NapzakThrottleButton.kt
@@ -1,0 +1,85 @@
+package com.napzak.market.designsystem.component.button
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+
+/**
+ * 연속적인 이벤트 실행을 방지하기 위해 스로틀링이 적용된 공통 기본 버튼 컴포넌트입니다.
+ *
+ * @param text 버튼에 표시될 텍스트
+ * @param onClick 버튼 클릭 시 실행할 로직
+ * @param enabled 버튼 활성화 여부 (기본값: true)
+ * @param icon 텍스트 오른쪽에 표시할 아이콘 (기본값: null)
+ * @param modifier 외부에서 버튼 크기나 위치 등을 조절할 수 있는 Modifier (기본값: Modifier)
+ */
+
+@Composable
+fun NapzakThrottleButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+    throttleTime: Long = 2000L
+) {
+    var lastClickTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    fun throttle() {
+        val now = System.currentTimeMillis()
+        if (now - lastClickTime > throttleTime) {
+            lastClickTime = now
+            onClick()
+        }
+    }
+
+    NapzakButton(
+        text = text,
+        onClick = ::throttle,
+        enabled = enabled,
+        icon = icon,
+        modifier = modifier
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NapzakThrottleButtonPreview() {
+    NapzakMarketTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .width(360.dp)
+        ) {
+            NapzakThrottleButton(
+                text = "다음으로",
+                onClick = {},
+                icon = ImageVector.vectorResource(id = R.drawable.ic_gray_arrow_right),
+                enabled = true,
+                modifier = Modifier
+                    .fillMaxWidth(),
+            )
+
+            NapzakThrottleButton(
+                text = "다음으로",
+                onClick = {},
+                icon = ImageVector.vectorResource(id = R.drawable.ic_gray_arrow_right),
+                enabled = false,
+                modifier = Modifier
+                    .fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/dialog/NapzakDialog.kt
@@ -1,7 +1,6 @@
 package com.napzak.market.designsystem.component.dialog
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,6 +23,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.napzak.market.designsystem.R.string.dialog_text_confirm
 import com.napzak.market.designsystem.R.string.dialog_text_dismiss
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.ui_util.throttledNoRippleClickable
 
 /**
  * 납작마켓 다이얼로그 컴포넌트입니다.
@@ -166,10 +165,7 @@ private fun DialogButton(
                 color = backgroundColor,
                 shape = RoundedCornerShape(12.dp),
             )
-            .clickable(
-                role = Role.Button,
-                onClick = onClick,
-            ),
+            .throttledNoRippleClickable(onClick = onClick),
     ) {
         Text(
             text = text,

--- a/core/ui_util/src/main/java/com/napzak/market/ui_util/ModifierExt.kt
+++ b/core/ui_util/src/main/java/com/napzak/market/ui_util/ModifierExt.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -96,6 +97,20 @@ inline fun Modifier.throttledNoRippleClickable(
                 onClick()
                 isClickable = true
             }
+        }
+    }
+}
+
+inline fun Modifier.throttledNoRippleClickable(
+    throttleTime: Long = 2000L,
+    crossinline onClick: () -> Unit,
+) = composed {
+    var lastClickTime by remember { mutableLongStateOf(0L) }
+    Modifier.noRippleClickable {
+        val now = System.currentTimeMillis()
+        if (now - lastClickTime > throttleTime) {
+            lastClickTime = now
+            onClick()
         }
     }
 }

--- a/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
-import com.napzak.market.designsystem.component.button.NapzakButton
+import com.napzak.market.designsystem.component.button.NapzakThrottleButton
 import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
 import com.napzak.market.designsystem.component.toast.ToastFontType
@@ -216,7 +216,7 @@ private fun ReportSubmitButton(
             .padding(horizontal = 20.dp)
             .padding(bottom = 20.dp, top = 6.dp),
     ) {
-        NapzakButton(
+        NapzakThrottleButton(
             text = stringResource(report_button_submit),
             onClick = onClick,
             enabled = enabled,

--- a/feature/store/src/main/java/com/napzak/market/store/edit_store/EditStoreScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/edit_store/EditStoreScreen.kt
@@ -38,7 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.common.state.UiState
 import com.napzak.market.designsystem.component.bottomsheet.GenreSearchBottomSheet
-import com.napzak.market.designsystem.component.button.NapzakButton
+import com.napzak.market.designsystem.component.button.NapzakThrottleButton
 import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.topbar.NavigateUpTopBar
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -264,7 +264,7 @@ private fun EditStoreProceedButton(
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 13.dp),
     ) {
-        NapzakButton(
+        NapzakThrottleButton(
             text = stringResource(store_edit_button_proceed),
             onClick = onClick,
             enabled = enabled,


### PR DESCRIPTION
## Related issue 🛠
- closed #341 

## Work Description ✏️
- `NapzakButton` 디자인에 스로틀을 적용한 컴포넌트를 구현했습니다.
- 코루틴을 제거한 Modifier 확장함수를 구현했습니다.
- 신고, 프로필 수정, 다이얼로그 버튼에 스로틀링을 적용했습니다.

## To Reviewers 📢
- POST, PUT 요청을 보내는 버튼들을 연타했을 때 요청이 많이 보내지는 것을 방지하기 위해 Modifier 확장함수와 기본 버튼 컴포넌트를 래핑하는 컴포넌트를 간단하게 만들어 봤습니다! 많관부~