### PR TITLE
[REFACTOR/#350] 2차 스프린트 담당화면 2차 QA

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/NapzakProfileImage.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/NapzakProfileImage.kt
@@ -32,6 +32,7 @@ fun NapzakProfileImage(
             .placeholder(ic_profile)
             .error(ic_profile)
             .fallback(ic_profile)
+            .crossfade(true)
             .build(),
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatText.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatText.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -37,7 +38,9 @@ internal fun ChatText(
     ) {
         Text(
             text = text,
-            style = textStyle,
+            style = textStyle.copy(
+                lineBreak = LineBreak.Simple
+            ),
             color = textColor,
             modifier = Modifier
                 .widthIn(max = maxWidth * 0.72f)

--- a/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationBuyGroup.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationBuyGroup.kt
@@ -66,7 +66,7 @@ private fun ProductConditionSection(
 
         Text(
             text = productCondition.label,
-            style = NapzakMarketTheme.typography.body14b.copy(
+            style = NapzakMarketTheme.typography.caption12sb.copy(
                 color = NapzakMarketTheme.colors.gray300,
             ),
             modifier = Modifier
@@ -74,7 +74,7 @@ private fun ProductConditionSection(
                     color = NapzakMarketTheme.colors.gray50,
                     shape = RoundedCornerShape(4.dp),
                 )
-                .padding(vertical = 6.dp, horizontal = 16.dp),
+                .padding(vertical = 6.dp, horizontal = 12.dp),
 
         )
     }

--- a/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationGroup.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationGroup.kt
@@ -87,7 +87,7 @@ internal fun ProductInformationGroup(
             Spacer(Modifier.height(10.dp))
             Text(
                 text = title,
-                style = NapzakMarketTheme.typography.title18m.copy(
+                style = NapzakMarketTheme.typography.title20sb.copy(
                     color = NapzakMarketTheme.colors.black,
                 ),
             )
@@ -95,7 +95,7 @@ internal fun ProductInformationGroup(
             Spacer(Modifier.height(10.dp))
             Text(
                 text = stringResource(detail_product_price, price),
-                style = NapzakMarketTheme.typography.title18b.copy(
+                style = NapzakMarketTheme.typography.title22b.copy(
                     color = NapzakMarketTheme.colors.black,
                 ),
             )
@@ -111,7 +111,7 @@ internal fun ProductInformationGroup(
 
         Text(
             text = description,
-            style = NapzakMarketTheme.typography.caption12r.copy(
+            style = NapzakMarketTheme.typography.body14r.copy(
                 color = NapzakMarketTheme.colors.black,
             ),
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
@@ -158,7 +158,7 @@ private fun TradeTypeTag(
 ) {
     Text(
         text = text,
-        style = NapzakMarketTheme.typography.caption10r.copy(
+        style = NapzakMarketTheme.typography.caption12sb.copy(
             color = contentColor,
         ),
         modifier = modifier

--- a/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductMarketGroup.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductMarketGroup.kt
@@ -9,16 +9,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -26,10 +23,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.napzak.market.designsystem.R.drawable.ic_white_arrow_right
-import com.napzak.market.designsystem.R.drawable.ic_circle_purple_user
+import com.napzak.market.designsystem.component.image.NapzakProfileImage
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.detail.R.string.detail_product_market_buy
 import com.napzak.market.feature.detail.R.string.detail_product_market_count
@@ -91,19 +86,10 @@ private fun ProductMarketProfile(
             .background(color = NapzakMarketTheme.colors.gray10, shape = RoundedCornerShape(25.dp))
             .padding(horizontal = 22.dp, vertical = 17.dp),
     ) {
-        AsyncImage(
-            model = ImageRequest.Builder(context)
-                .placeholder(ic_circle_purple_user)
-                .error(ic_circle_purple_user)
-                .fallback(ic_circle_purple_user)
-                .data(marketImage.ifBlank { null })
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(60.dp)
-                .clip(shape = CircleShape),
+        NapzakProfileImage(
+            imageUrl = marketImage,
+            contentDescription = marketName,
+            modifier = Modifier.size(60.dp),
         )
 
         Spacer(Modifier.width(14.dp))

--- a/feature/detail/src/main/java/com/napzak/market/detail/type/ProductDetailToastType.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/type/ProductDetailToastType.kt
@@ -2,11 +2,12 @@ package com.napzak.market.detail.type
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.napzak.market.designsystem.R.drawable.ic_white_checked
 import com.napzak.market.designsystem.R.drawable.ic_gray_trash_bin
+import com.napzak.market.designsystem.R.drawable.ic_white_checked
 import com.napzak.market.designsystem.R.string.heart_click_snackbar_message
 import com.napzak.market.designsystem.component.toast.ToastFontType
 import com.napzak.market.designsystem.component.toast.ToastType
+import com.napzak.market.feature.detail.R.string.detail_toast_delete
 import com.napzak.market.feature.detail.R.string.detail_toast_trade_status
 
 enum class ProductDetailToastType(
@@ -18,7 +19,7 @@ enum class ProductDetailToastType(
     DELETE(
         toastType = ToastType.COMMON,
         fontType = ToastFontType.LARGE,
-        stringRes = detail_toast_trade_status,
+        stringRes = detail_toast_delete,
         iconRes = ic_gray_trash_bin,
     ),
     STATUS_CHANGE(

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
 
     <!--SignOutScreen-->
     <string name="sign_out_top_bar">탈퇴하기</string>
-    <string name="sign_out_button_proceed">제출하기</string>
+    <string name="sign_out_button_proceed">계속하기</string>
     <string name="sign_out_button_skip">건너뛰기</string>
     <string name="sign_out_reason_title">정말 떠나시나요?</string>
     <string name="sign_out_reason_description">


### PR DESCRIPTION
## Related issue 🛠
- closed #350 

## Work Description ✏️

- 탈퇴 버튼 라이팅 (제출 -> 계속)
- 상품상세 삭제 토스트바 라이팅 ("삭제" 문구 추가)
- 상품상세 화면 디자인 (폰트, 아이콘 등)

## Screenshot 📸

| 탈퇴 버튼 라이팅  | 상품상세 화면 디자인 |
|:---:|:---|
| <img width="411" height="434" alt="image" src="https://github.com/user-attachments/assets/889c90af-1079-4c13-8791-aea9a4c91b13" />  | <img width="434" height="765" alt="image" src="https://github.com/user-attachments/assets/04c32df4-7f57-4bf9-ba65-b6653982cd1d" /> | 

## To Reviewers 📢
- 채팅을 제외한 다른 화면들의 마지막 QA를 해결했습니다!