### PR TITLE
[FIX/#359] 최종 QA

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakLargeProductItem.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakLargeProductItem.kt
@@ -47,9 +47,10 @@ import com.napzak.market.designsystem.R.drawable.img_thumbnail_complete_buy
 import com.napzak.market.designsystem.R.drawable.img_thumbnail_complete_sell
 import com.napzak.market.designsystem.R.drawable.img_thumbnail_reservation
 import com.napzak.market.designsystem.R.string.production_item_buy
-import com.napzak.market.designsystem.R.string.production_item_price
+import com.napzak.market.designsystem.R.string.production_item_buy_price
 import com.napzak.market.designsystem.R.string.production_item_price_suggestion
 import com.napzak.market.designsystem.R.string.production_item_sell
+import com.napzak.market.designsystem.R.string.production_item_sell_price
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.noRippleClickable
@@ -128,13 +129,9 @@ fun NapzakLargeProductItem(
             modifier = Modifier.padding(top = 2.dp),
         )
 
-        Text(
-            text = stringResource(production_item_price, price.formatToPriceString()),
-            style = NapzakMarketTheme.typography.body16b,
-            color = NapzakMarketTheme.colors.gray500,
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
-            modifier = Modifier.padding(top = 6.dp),
+        PriceText(
+            price = price,
+            isSellElseBuy = isSellElseBuy
         )
 
         Row(
@@ -323,6 +320,27 @@ private fun LikeButton(
         modifier = modifier
             .clearAndSetSemantics { role = Role.Button }
             .noRippleClickable(onClick = onLikeClick)
+    )
+}
+
+@Composable
+private fun PriceText(
+    price: String,
+    isSellElseBuy: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val priceText = price.formatToPriceString()
+    val textRes =
+        if (isSellElseBuy) production_item_sell_price
+        else production_item_buy_price
+
+    Text(
+        text = stringResource(textRes, priceText),
+        style = NapzakMarketTheme.typography.body16b,
+        color = NapzakMarketTheme.colors.gray500,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = modifier.padding(top = 6.dp),
     )
 }
 

--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakSmallProductItem.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/productItem/NapzakSmallProductItem.kt
@@ -39,10 +39,12 @@ import coil.request.ImageRequest
 import com.napzak.market.designsystem.R.drawable.ic_red_heart
 import com.napzak.market.designsystem.R.drawable.ic_transparent_heart
 import com.napzak.market.designsystem.R.string.production_item_buy
-import com.napzak.market.designsystem.R.string.production_item_price
+import com.napzak.market.designsystem.R.string.production_item_buy_price
 import com.napzak.market.designsystem.R.string.production_item_price_suggestion
 import com.napzak.market.designsystem.R.string.production_item_sell
+import com.napzak.market.designsystem.R.string.production_item_sell_price
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.noRippleClickable
 
 /**
@@ -109,13 +111,9 @@ fun NapzakSmallProductItem(
             modifier = Modifier.padding(top = 2.dp),
         )
 
-        Text(
-            text = stringResource(production_item_price, price),
-            style = NapzakMarketTheme.typography.body16b,
-            color = NapzakMarketTheme.colors.gray500,
-            overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
-            modifier = Modifier.padding(top = 2.dp),
+        PriceText(
+            price = price,
+            isSellElseBuy = isSellElseBuy,
         )
     }
 }
@@ -242,6 +240,27 @@ private fun LikeButton(
             .clearAndSetSemantics { role = Role.Button }
             .size(14.dp)
             .noRippleClickable(onClick = onLikeClick),
+    )
+}
+
+@Composable
+private fun PriceText(
+    price: String,
+    isSellElseBuy: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val priceText = price.formatToPriceString()
+    val textRes =
+        if (isSellElseBuy) production_item_sell_price
+        else production_item_buy_price
+
+    Text(
+        text = stringResource(textRes, priceText),
+        style = NapzakMarketTheme.typography.body16b,
+        color = NapzakMarketTheme.colors.gray500,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = modifier.padding(top = 2.dp),
     )
 }
 

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -17,7 +17,8 @@
 
 
     <!--ProductItem-->
-    <string name="production_item_price">%s원</string>
+    <string name="production_item_sell_price">%s원</string>
+    <string name="production_item_buy_price">%s원대</string>
     <string name="production_item_sell">팔아요</string>
     <string name="production_item_buy">구해요</string>
     <string name="production_item_price_suggestion">가격제시</string>

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomViewModel.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomViewModel.kt
@@ -188,7 +188,6 @@ internal class ChatRoomViewModel @Inject constructor(
         collectJob = viewModelScope.launch {
             getChatFlowUseCase(roomId)
                 .collect { message ->
-                    Timber.d("수신한 메시지: $message")
                     if (message.roomId == roomId) {
                         _sideEffect.send(ChatRoomSideEffect.OnReceiveChatMessage)
 
@@ -458,13 +457,14 @@ internal class ChatRoomViewModel @Inject constructor(
                 val roomId = requireNotNull(_chatRoomStateAsSuccess.roomId)
                 chatRepository.withdrawChatRoom(roomId).onSuccess {
                     unsubscribeChatRoomUseCase(roomId)
-                    _sideEffect.trySend(ChatRoomSideEffect.OnWithdrawChatRoom)
                 }
             } catch (e: Exception) {
                 when (e) {
                     is IllegalArgumentException -> Timber.w("채팅방이 생성되지 않았습니다.")
                     else -> Timber.e(e)
                 }
+            } finally {
+                _sideEffect.trySend(ChatRoomSideEffect.OnWithdrawChatRoom)
             }
         }
     }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomViewModel.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomViewModel.kt
@@ -253,8 +253,15 @@ internal class ChatRoomViewModel @Inject constructor(
             }
         }
 
+        // TODO: 과도한 경고 메시지 출력을 방지하기 위한 임시 조치
         if (added) {
-            chatMessageList.sortBy { it.messageId }
+            chatMessageList
+                .apply {
+                    removeAll {
+                        it is ReceiveMessage.Notice && it.messageId != chatMessageList.last().messageId
+                    }
+                }
+                .sortBy { it.messageId }
             _chatItems.update { chatMessageList.toList() }
         }
     }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomProduct.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomProduct.kt
@@ -32,9 +32,10 @@ import coil.request.ImageRequest
 import com.napzak.market.chat.model.ProductBrief
 import com.napzak.market.common.type.TradeType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.chat.R.string.chat_room_product_buy_price_won_format
 import com.napzak.market.feature.chat.R.string.chat_room_product_deleted
 import com.napzak.market.feature.chat.R.string.chat_room_product_negotiable
-import com.napzak.market.feature.chat.R.string.chat_room_product_price_won_format
+import com.napzak.market.feature.chat.R.string.chat_room_product_sell_price_won_format
 import com.napzak.market.ui_util.ShadowDirection
 import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.napzakGradientShadow
@@ -48,6 +49,10 @@ internal fun ChatRoomProductSection(
 ) {
     val innerPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp)
     val alpha = if (product.isProductDeleted) 0.6f else 1f
+    val priceStringId = when (TradeType.fromName(product.tradeType)) {
+        TradeType.SELL -> chat_room_product_sell_price_won_format
+        TradeType.BUY -> chat_room_product_buy_price_won_format
+    }
 
     Row(
         modifier = modifier
@@ -85,7 +90,7 @@ internal fun ChatRoomProductSection(
             )
             ProductText(
                 text = stringResource(
-                    chat_room_product_price_won_format,
+                    priceStringId,
                     product.price.toString().formatToPriceString(),
                 ),
                 style = NapzakMarketTheme.typography.body16b,

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
@@ -31,8 +31,10 @@ import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.chat.R.string.chat_room_product_button
 import com.napzak.market.feature.chat.R.string.chat_room_product_deleted_button
 import com.napzak.market.feature.chat.R.string.chat_room_product_price_won_format
-import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy
-import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell
+import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_received
+import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_sent
+import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_received
+import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_sent
 import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.noRippleClickable
 import timber.log.Timber
@@ -72,6 +74,7 @@ internal fun ChatProduct(
         ) {
             ChatProductHeader(
                 tradeType = product.tradeType,
+                isMessageOwner = isMessageOwner,
             )
             Spacer(
                 modifier = Modifier.height(16.dp),
@@ -103,11 +106,16 @@ internal fun ChatProduct(
 @Composable
 private fun ChatProductHeader(
     tradeType: String,
+    isMessageOwner: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val stringRes = when (TradeType.fromName(tradeType)) {
-        TradeType.SELL -> chat_room_product_title_sell
-        TradeType.BUY -> chat_room_product_title_buy
+    val tradeType = TradeType.fromName(tradeType)
+    val stringRes = when {
+        tradeType == TradeType.SELL && isMessageOwner -> chat_room_product_title_sell_sent
+        tradeType == TradeType.SELL && !isMessageOwner -> chat_room_product_title_sell_received
+        tradeType == TradeType.BUY && isMessageOwner -> chat_room_product_title_buy_sent
+        tradeType == TradeType.BUY && !isMessageOwner -> chat_room_product_title_buy_received
+        else -> return
     }
     val textStyle = NapzakMarketTheme.typography.caption12sb
     val contentColor = NapzakMarketTheme.colors.white
@@ -211,7 +219,7 @@ private fun ChatProductPreview() {
                     isProductDeleted = true
                 ),
                 onNavigateClick = {},
-                isMessageOwner = true
+                isMessageOwner = false
             )
         }
     }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
@@ -36,6 +36,7 @@ import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_recei
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_sent
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_received
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_sent
+import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.noRippleClickable
 import timber.log.Timber
 
@@ -82,7 +83,7 @@ internal fun ChatProduct(
             ChatProductDetailView(
                 genre = product.genreName,
                 name = product.title,
-                price = product.price.toString(),
+                price = product.price.toString().formatToPriceString(),
                 tradeType = TradeType.fromName(product.tradeType),
                 modifier = Modifier.padding(horizontal = 20.dp),
             )

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/chatitem/ChatProduct.kt
@@ -29,13 +29,13 @@ import com.napzak.market.chat.model.ProductBrief
 import com.napzak.market.common.type.TradeType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.chat.R.string.chat_room_product_button
+import com.napzak.market.feature.chat.R.string.chat_room_product_buy_price_won_format
 import com.napzak.market.feature.chat.R.string.chat_room_product_deleted_button
-import com.napzak.market.feature.chat.R.string.chat_room_product_price_won_format
+import com.napzak.market.feature.chat.R.string.chat_room_product_sell_price_won_format
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_received
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_buy_sent
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_received
 import com.napzak.market.feature.chat.R.string.chat_room_product_title_sell_sent
-import com.napzak.market.ui_util.formatToPriceString
 import com.napzak.market.ui_util.noRippleClickable
 import timber.log.Timber
 
@@ -82,10 +82,8 @@ internal fun ChatProduct(
             ChatProductDetailView(
                 genre = product.genreName,
                 name = product.title,
-                price = stringResource(
-                    chat_room_product_price_won_format,
-                    product.price.toString().formatToPriceString(),
-                ),
+                price = product.price.toString(),
+                tradeType = TradeType.fromName(product.tradeType),
                 modifier = Modifier.padding(horizontal = 20.dp),
             )
             Spacer(
@@ -138,8 +136,14 @@ private fun ChatProductDetailView(
     genre: String,
     name: String,
     price: String,
+    tradeType: TradeType,
     modifier: Modifier = Modifier,
 ) {
+    val priceText = when (tradeType) {
+        TradeType.SELL -> stringResource(chat_room_product_sell_price_won_format, price)
+        TradeType.BUY -> stringResource(chat_room_product_buy_price_won_format, price)
+    }
+
     val textColor = NapzakMarketTheme.colors.black
     val commonText: @Composable (String, TextStyle) -> Unit = { text, style ->
         Text(
@@ -160,7 +164,7 @@ private fun ChatProductDetailView(
     ) {
         commonText(genre, NapzakMarketTheme.typography.caption10sb)
         commonText(name, NapzakMarketTheme.typography.caption12sb)
-        commonText(price, NapzakMarketTheme.typography.body14b)
+        commonText(priceText, NapzakMarketTheme.typography.body14b)
     }
 }
 

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -7,7 +7,8 @@
     <string name="chat_room_is_not_read">1</string>
     <string name="chat_room_product_negotiable">가격 제시</string>
     <string name="chat_room_product_deleted">%s (삭제됨)</string>
-    <string name="chat_room_product_price_won_format">%s원</string>
+    <string name="chat_room_product_sell_price_won_format">%s원</string>
+    <string name="chat_room_product_buy_price_won_format">%s원대</string>
 
 
     <string name="chat_room_bottom_sheet_report">마켓 신고하기</string>

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -13,8 +13,10 @@
     <string name="chat_room_bottom_sheet_report">마켓 신고하기</string>
     <string name="chat_room_bottom_sheet_exit">채팅방 나가기</string>
 
-    <string name="chat_room_product_title_sell">팔아요 상품 문의가 도착했어요!</string>
-    <string name="chat_room_product_title_buy">구해요 상품 문의가 도착했어요!</string>
+    <string name="chat_room_product_title_sell_received">팔아요 상품 문의가 도착했어요!</string>
+    <string name="chat_room_product_title_buy_received">구해요 상품 문의가 도착했어요!</string>
+    <string name="chat_room_product_title_sell_sent">팔아요 상품 문의를 전송했어요!</string>
+    <string name="chat_room_product_title_buy_sent">구해요 상품 문의를 전송했어요!</string>
     <string name="chat_room_product_button">상품 보러 가기</string>
     <string name="chat_room_product_deleted_button">삭제된 상품입니다.</string>
 

--- a/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationGroup.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/component/group/ProductInformationGroup.kt
@@ -30,7 +30,8 @@ import com.napzak.market.designsystem.R.drawable.ic_gray_heart
 import com.napzak.market.designsystem.R.drawable.ic_gray_review
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.detail.R.string.detail_product_count_overflow
-import com.napzak.market.feature.detail.R.string.detail_product_price
+import com.napzak.market.feature.detail.R.string.detail_product_price_buy
+import com.napzak.market.feature.detail.R.string.detail_product_price_sell
 import com.napzak.market.feature.detail.R.string.detail_product_tag_is_price_negotiable
 
 @Composable
@@ -47,6 +48,10 @@ internal fun ProductInformationGroup(
     modifier: Modifier = Modifier,
 ) {
     val shadowColor = NapzakMarketTheme.colors.gray100.copy(alpha = 0.2f)
+    val priceStringId = when (tradeType) {
+        TradeType.SELL -> detail_product_price_sell
+        TradeType.BUY -> detail_product_price_buy
+    }
 
     Column(
         modifier = modifier.background(NapzakMarketTheme.colors.white),
@@ -94,7 +99,7 @@ internal fun ProductInformationGroup(
 
             Spacer(Modifier.height(10.dp))
             Text(
-                text = stringResource(detail_product_price, price),
+                text = stringResource(priceStringId, price),
                 style = NapzakMarketTheme.typography.title22b.copy(
                     color = NapzakMarketTheme.colors.black,
                 ),

--- a/feature/detail/src/main/res/values/strings.xml
+++ b/feature/detail/src/main/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="detail_product_tag_is_price_negotiable">가격제시</string>
     <string name="detail_product_count_overflow">999+</string>
 
-    <string name="detail_product_price">%s원</string>
+    <string name="detail_product_price_sell">%s원</string>
+    <string name="detail_product_price_buy">%s원대</string>
     <string name="detail_product_title_is_price_negotiable">가격 제시</string>
     <string name="detail_product_is_price_negotiable_true">받음</string>
     <string name="detail_product_is_price_negotiable_false">받지않음</string>

--- a/feature/home/src/main/java/com/napzak/market/home/component/HorizontalAutoScrollableImages.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/component/HorizontalAutoScrollableImages.kt
@@ -71,12 +71,18 @@ internal fun HorizontalAutoScrolledImages(
         contentAlignment = Alignment.BottomCenter,
         modifier = modifier
             .background(color = NapzakMarketTheme.colors.gray100)
-            .noRippleClickable { onImageClick(pagerState.currentPage % images.size) }
+            .noRippleClickable {
+                if (images.isNotEmpty()) {
+                    onImageClick(pagerState.currentPage % images.size)
+                }
+            }
     ) {
         HorizontalPager(
             state = pagerState,
         ) { page ->
-            val currentPage = page % images.size
+            val currentPage =
+                if (images.isNotEmpty()) page % images.size
+                else 0
             val currentImage = images[currentPage]
             AsyncImage(
                 model = ImageRequest

--- a/feature/home/src/main/java/com/napzak/market/home/component/HorizontalAutoScrollableImages.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/component/HorizontalAutoScrollableImages.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,10 +56,6 @@ internal fun HorizontalAutoScrolledImages(
         pageCount = { Int.MAX_VALUE },
     )
 
-    val currentPage = rememberSaveable(pagerState) {
-        pagerState.currentPage % images.size
-    }
-
     LaunchedEffect(Unit) {
         pagerState.scrollToPage(page = 0, pageOffsetFraction = 0f)
         while (true) {
@@ -76,11 +71,12 @@ internal fun HorizontalAutoScrolledImages(
         contentAlignment = Alignment.BottomCenter,
         modifier = modifier
             .background(color = NapzakMarketTheme.colors.gray100)
-            .noRippleClickable { onImageClick(currentPage) }
+            .noRippleClickable { onImageClick(pagerState.currentPage % images.size) }
     ) {
         HorizontalPager(
             state = pagerState,
-        ) {
+        ) { page ->
+            val currentPage = page % images.size
             val currentImage = images[currentPage]
             AsyncImage(
                 model = ImageRequest

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/setting/component/SettingNotificationItem.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/setting/component/SettingNotificationItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.napzak.market.designsystem.component.button.NapzakToggleButton
+import com.napzak.market.designsystem.component.button.NapzakToggleButtonDefault
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.mypage.R.string.settings_section_app_notification_off_title
 import com.napzak.market.feature.mypage.R.string.settings_section_app_notification_title
@@ -27,6 +28,9 @@ fun SettingNotificationItem(
     val textColor =
         if (!isSystemPermissionOn) NapzakMarketTheme.colors.transRed
         else NapzakMarketTheme.colors.gray400
+    val toggleColor =
+        if (!isSystemPermissionOn) NapzakMarketTheme.colors.purple200
+        else NapzakMarketTheme.colors.purple500
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -41,6 +45,9 @@ fun SettingNotificationItem(
         NapzakToggleButton(
             isToggleOn = isAppNotificationOn,
             onToggleClick = onToggleClick,
+            toggleButtonColor = NapzakToggleButtonDefault.color.copy(
+                toggleOnColor = toggleColor
+            )
         )
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #359 

## Work Description ✏️
- 홈 배너에서 첫 이미지만 보이는 오류 해결
- 기기의 알림 권한이 비활성화 상태이고, 앱의 알림 권한은 활성화 상태일 때의 토글 색상 수정
- 채팅방 탈퇴 시 예외 처리 보완
- 경고 메시지가 많이 표시되는 상황을 방지하기 위한 필터링 코드 추가 (임시방편)
- "내가 보낸 물품 메시지"의 제목 라이팅 수정
- 구해요 물품의 가격 표시를 "원"에서 "원대"로 수정

## Screenshot 📸

### 물품 가격 표시 (구해요는 "원대" + 가격 포맷)
| <img src="https://github.com/user-attachments/assets/0b05f022-748e-4bf9-b806-d0f93d1b7c43" width="360"/> | <img src="https://github.com/user-attachments/assets/36ee73da-6c35-4862-9de7-d2c840613a5b" width="360"/> | <img src="https://github.com/user-attachments/assets/fc18d629-4c20-436b-9e6a-344d157d2346" width="360"/> | <img src="https://github.com/user-attachments/assets/41822e79-0843-462c-94c3-c720a3761ae8" width="360"/> |
|:---:|:---:|:---:|:---:|

<br>

### 홈 배너

https://github.com/user-attachments/assets/ba7ee67d-51ef-400e-aae2-7f80e0a3c4fe

<br>

### 알림 토클
<img src="https://github.com/user-attachments/assets/417633d6-8723-4edd-8357-a4b0b0b18201" width="360"/>

## To Reviewers 📢
- 최종 QA PR입니다~ 