### PR TITLE
[mod/#361] 필터부분 항상 보이도록 수정

### DIFF
--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -253,9 +256,13 @@ private fun ExploreSuccessScreen(
         skipPartiallyExpanded = true
     )
     val listState = rememberLazyListState()
+    var lastSelectedTab by remember { mutableStateOf(selectedTab) }
 
     LaunchedEffect(selectedTab) {
-        listState.animateScrollToItem(0)
+        if (lastSelectedTab!= selectedTab) {
+            lastSelectedTab = selectedTab
+            listState.animateScrollToItem(0)
+        }
     }
 
     Column(

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -219,8 +219,6 @@ private fun ExploreScreen(
             }
         }
     }
-
-
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -281,48 +279,49 @@ private fun ExploreSuccessScreen(
             modifier = Modifier.padding(horizontal = 20.dp),
         )
 
-        if (productCount != 0 || searchTerm.isNullOrEmpty()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(color = NapzakMarketTheme.colors.gray10)
-                    .padding(horizontal = 20.dp)
-                    .padding(top = 15.dp, bottom = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                GenreFilterChip(
-                    genreList = filteredGenres,
-                    onChipClick = onGenreFilterClick,
-                )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = NapzakMarketTheme.colors.gray10)
+                .padding(horizontal = 20.dp)
+                .padding(top = 15.dp, bottom = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            GenreFilterChip(
+                genreList = filteredGenres,
+                onChipClick = onGenreFilterClick,
+            )
 
-                if (selectedTab == TradeType.SELL) {
-                    BasicFilterChip(
-                        filterName = stringResource(explore_unopened),
-                        isClicked = isUnopenSelected,
-                        onChipClick = onUnopenFilterClick,
-                    )
-                }
-
+            if (selectedTab == TradeType.SELL) {
                 BasicFilterChip(
-                    filterName = stringResource(explore_exclude_sold_out),
-                    isClicked = isSoldOutSelected,
-                    onChipClick = onExcludeSoldOutFilterClick,
+                    filterName = stringResource(explore_unopened),
+                    isClicked = isUnopenSelected,
+                    onChipClick = onUnopenFilterClick,
                 )
             }
 
-            GenreAndProductList(
-                genreList = filteredGenres,
-                productListState = listState,
-                productCount = productCount,
-                productList = products,
-                sortType = sortOption,
-                onGenreButtonClick = onGenreDetailNavigate,
-                onSortOptionClick = { onSortOptionClick(sortOption) },
-                onProductClick = onProductDetailNavigate,
-                onLikeButtonClick = onLikeButtonClick,
+            BasicFilterChip(
+                filterName = stringResource(explore_exclude_sold_out),
+                isClicked = isSoldOutSelected,
+                onChipClick = onExcludeSoldOutFilterClick,
             )
-        } else {
-            if (searchTerm.isNotEmpty()) EmptySearchResultView()
+        }
+
+        GenreAndProductList(
+            searchTerm = searchTerm,
+            genreList = filteredGenres,
+            productListState = listState,
+            productCount = productCount,
+            productList = products,
+            sortType = sortOption,
+            onGenreButtonClick = onGenreDetailNavigate,
+            onSortOptionClick = { onSortOptionClick(sortOption) },
+            onProductClick = onProductDetailNavigate,
+            onLikeButtonClick = onLikeButtonClick,
+        )
+
+        if (!searchTerm.isNullOrEmpty() && productCount==0) {
+            EmptySearchResultView()
         }
     }
 
@@ -395,6 +394,7 @@ private fun ExploreSearchTextField(
 
 @Composable
 private fun GenreAndProductList(
+    searchTerm: String?,
     genreList: List<Genre>,
     productListState: LazyListState,
     productCount: Int,
@@ -408,7 +408,6 @@ private fun GenreAndProductList(
     LazyColumn(
         state = productListState,
         modifier = Modifier
-            .fillMaxSize()
             .background(color = NapzakMarketTheme.colors.white),
     ) {
         item {
@@ -426,92 +425,95 @@ private fun GenreAndProductList(
                         )
                     }
                 }
+            }
+        }
 
+        if (productList.isNotEmpty() || searchTerm.isNullOrEmpty()) {
+            item {
+                Column {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 20.dp, top = 20.dp, end = 20.dp),
+                    ) {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.gray500)) {
+                                    append(stringResource(explore_product))
+                                }
+                                withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.purple500)) {
+                                    append(stringResource(explore_count, productCount))
+                                }
+                            },
+                            style = NapzakMarketTheme.typography.body14sb,
+                        )
+
+                        Spacer(Modifier.weight(1f))
+
+                        Row(
+                            modifier = Modifier.noRippleClickable(onSortOptionClick),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = sortType.label,
+                                style = NapzakMarketTheme.typography.caption12sb,
+                                color = NapzakMarketTheme.colors.gray200,
+                            )
+
+                            Spacer(Modifier.width(3.dp))
+
+                            Icon(
+                                imageVector = ImageVector.vectorResource(ic_gray_arrow_down),
+                                contentDescription = null,
+                                tint = NapzakMarketTheme.colors.gray200,
+                                modifier = Modifier.size(width = 7.dp, height = 4.dp),
+                            )
+                        }
+                    }
+                }
+            }
+
+            itemsIndexed(productList.chunked(2)) { index, rowItems ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 20.dp, top = 20.dp, end = 20.dp),
+                        .padding(top = 20.dp)
+                        .padding(horizontal = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
-                    Text(
-                        text = buildAnnotatedString {
-                            withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.gray500)) {
-                                append(stringResource(explore_product))
-                            }
-                            withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.purple500)) {
-                                append(stringResource(explore_count, productCount))
-                            }
-                        },
-                        style = NapzakMarketTheme.typography.body14sb,
-                    )
+                    rowItems.forEach { product ->
+                        with(product) {
+                            NapzakLargeProductItem(
+                                genre = genreName,
+                                title = productName,
+                                imgUrl = photo,
+                                price = price.toString(),
+                                createdDate = uploadTime,
+                                reviewCount = chatCount.toString(),
+                                likeCount = interestCount.toString(),
+                                isLiked = isInterested,
+                                isMyItem = isOwnedByCurrentUser,
+                                isSellElseBuy = TradeType.valueOf(tradeType) == TradeType.SELL,
+                                isSuggestionAllowed = isPriceNegotiable,
+                                tradeStatus = TradeStatusType.get(
+                                    tradeStatus, TradeType.valueOf(tradeType)
+                                ),
+                                onLikeClick = { onLikeButtonClick(productId, isInterested) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .noRippleClickable { onProductClick(productId, tradeType) },
+                            )
+                        }
+                    }
 
-                    Spacer(Modifier.weight(1f))
-
-                    Row(
-                        modifier = Modifier.noRippleClickable(onSortOptionClick),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = sortType.label,
-                            style = NapzakMarketTheme.typography.caption12sb,
-                            color = NapzakMarketTheme.colors.gray200,
-                        )
-
-                        Spacer(Modifier.width(3.dp))
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(ic_gray_arrow_down),
-                            contentDescription = null,
-                            tint = NapzakMarketTheme.colors.gray200,
-                            modifier = Modifier.size(width = 7.dp, height = 4.dp),
-                        )
+                    if (rowItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
                     }
                 }
             }
+
+            item { Spacer(Modifier.height(32.dp)) }
         }
-
-        itemsIndexed(productList.chunked(2)) { index, rowItems ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 20.dp)
-                    .padding(horizontal = 20.dp),
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
-            ) {
-                rowItems.forEach { product ->
-                    with(product) {
-                        NapzakLargeProductItem(
-                            genre = genreName,
-                            title = productName,
-                            imgUrl = photo,
-                            price = price.toString(),
-                            createdDate = uploadTime,
-                            reviewCount = chatCount.toString(),
-                            likeCount = interestCount.toString(),
-                            isLiked = isInterested,
-                            isMyItem = isOwnedByCurrentUser,
-                            isSellElseBuy = TradeType.valueOf(tradeType) == TradeType.SELL,
-                            isSuggestionAllowed = isPriceNegotiable,
-                            tradeStatus = TradeStatusType.get(
-                                tradeStatus, TradeType.valueOf(tradeType)
-                            ),
-                            onLikeClick = { onLikeButtonClick(productId, isInterested) },
-                            modifier = Modifier
-                                .weight(1f)
-                                .noRippleClickable { onProductClick(productId, tradeType) },
-                        )
-                    }
-                }
-
-                if (rowItems.size == 1) {
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-            }
-        }
-
-        item {
-            Spacer(Modifier.height(32.dp))
-        }
-
     }
 }
 

--- a/feature/store/src/main/java/com/napzak/market/store/store/component/StoreScrollSection.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/component/StoreScrollSection.kt
@@ -103,125 +103,123 @@ internal fun StoreScrollSection(
             )
 
 //            if (selectedTab != MarketTab.REVIEW && productCount != 0) {
-            if (productCount != 0) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(color = NapzakMarketTheme.colors.gray10)
-                        .padding(horizontal = 20.dp)
-                        .padding(top = 15.dp, bottom = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    GenreFilterChip(
-                        genreList = filteredGenres,
-                        onChipClick = onGenreFilterClick,
-                    )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = NapzakMarketTheme.colors.gray10)
+                    .padding(horizontal = 20.dp)
+                    .padding(top = 15.dp, bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                GenreFilterChip(
+                    genreList = filteredGenres,
+                    onChipClick = onGenreFilterClick,
+                )
 
-                    BasicFilterChip(
-                        filterName = filterChipName,
-                        isClicked = isOnSale,
-                        onChipClick = onFilterClick,
-                    )
-                }
+                BasicFilterChip(
+                    filterName = filterChipName,
+                    isClicked = isOnSale,
+                    onChipClick = onFilterClick,
+                )
             }
         }
 
 //        if (selectedTab != MarketTab.REVIEW) {
-            if (productCount == 0) {
-                item {
-                    StoreEmptyView(
-                        isOwner = isOwner,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-            } else {
-                item {
-                    Column {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(start = 20.dp, top = 20.dp, end = 20.dp),
-                        ) {
-                            Text(
-                                text = buildAnnotatedString {
-                                    withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.gray500)) {
-                                        append(stringResource(store_product))
-                                    }
-                                    withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.purple500)) {
-                                        append(stringResource(store_count, productCount))
-                                    }
-                                },
-                                style = NapzakMarketTheme.typography.body14sb,
-                            )
-
-                            Spacer(Modifier.weight(1f))
-
-                            Row(
-                                modifier = Modifier.noRippleClickable { onSortOptionClick(sortType) },
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(
-                                    text = sortType.label,
-                                    style = NapzakMarketTheme.typography.caption12sb,
-                                    color = NapzakMarketTheme.colors.gray200,
-                                )
-
-                                Spacer(Modifier.width(3.dp))
-
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(ic_down_chevron_7),
-                                    contentDescription = null,
-                                    tint = NapzakMarketTheme.colors.gray200,
-                                    modifier = Modifier.size(width = 7.dp, height = 4.dp),
-                                )
-                            }
-                        }
-                    }
-                }
-
-                itemsIndexed(productList.chunked(2)) { index, rowItems ->
+        if (productCount == 0) {
+            item {
+                StoreEmptyView(
+                    isOwner = isOwner,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        } else {
+            item {
+                Column {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 20.dp)
-                            .padding(horizontal = 20.dp),
-                        horizontalArrangement = Arrangement.spacedBy(20.dp),
+                            .padding(start = 20.dp, top = 20.dp, end = 20.dp),
                     ) {
-                        rowItems.forEach { product ->
-                            with(product) {
-                                NapzakLargeProductItem(
-                                    genre = genreName,
-                                    title = productName,
-                                    imgUrl = photo,
-                                    price = price.toString(),
-                                    createdDate = uploadTime,
-                                    reviewCount = chatCount.toString(),
-                                    likeCount = interestCount.toString(),
-                                    isLiked = isInterested,
-                                    isMyItem = isOwnedByCurrentUser,
-                                    isSellElseBuy = TradeType.valueOf(tradeType) == TradeType.SELL,
-                                    isSuggestionAllowed = isPriceNegotiable,
-                                    tradeStatus = TradeStatusType.get(
-                                        tradeStatus, TradeType.valueOf(tradeType)
-                                    ),
-                                    onLikeClick = { onLikeButtonClick(productId, isInterested) },
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .noRippleClickable { onProductDetailNavigate(productId) },
-                                )
-                            }
-                        }
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.gray500)) {
+                                    append(stringResource(store_product))
+                                }
+                                withStyle(style = SpanStyle(color = NapzakMarketTheme.colors.purple500)) {
+                                    append(stringResource(store_count, productCount))
+                                }
+                            },
+                            style = NapzakMarketTheme.typography.body14sb,
+                        )
 
-                        if (rowItems.size == 1) {
-                            Spacer(modifier = Modifier.weight(1f))
+                        Spacer(Modifier.weight(1f))
+
+                        Row(
+                            modifier = Modifier.noRippleClickable { onSortOptionClick(sortType) },
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = sortType.label,
+                                style = NapzakMarketTheme.typography.caption12sb,
+                                color = NapzakMarketTheme.colors.gray200,
+                            )
+
+                            Spacer(Modifier.width(3.dp))
+
+                            Icon(
+                                imageVector = ImageVector.vectorResource(ic_down_chevron_7),
+                                contentDescription = null,
+                                tint = NapzakMarketTheme.colors.gray200,
+                                modifier = Modifier.size(width = 7.dp, height = 4.dp),
+                            )
                         }
                     }
                 }
+            }
 
-                item {
-                    Spacer(Modifier.padding(bottom = 32.dp))
+            itemsIndexed(productList.chunked(2)) { index, rowItems ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 20.dp)
+                        .padding(horizontal = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    rowItems.forEach { product ->
+                        with(product) {
+                            NapzakLargeProductItem(
+                                genre = genreName,
+                                title = productName,
+                                imgUrl = photo,
+                                price = price.toString(),
+                                createdDate = uploadTime,
+                                reviewCount = chatCount.toString(),
+                                likeCount = interestCount.toString(),
+                                isLiked = isInterested,
+                                isMyItem = isOwnedByCurrentUser,
+                                isSellElseBuy = TradeType.valueOf(tradeType) == TradeType.SELL,
+                                isSuggestionAllowed = isPriceNegotiable,
+                                tradeStatus = TradeStatusType.get(
+                                    tradeStatus, TradeType.valueOf(tradeType)
+                                ),
+                                onLikeClick = { onLikeButtonClick(productId, isInterested) },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .noRippleClickable { onProductDetailNavigate(productId) },
+                            )
+                        }
+                    }
+
+                    if (rowItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
                 }
             }
+
+            item {
+                Spacer(Modifier.padding(bottom = 32.dp))
+            }
+        }
 //        }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #361

## Work Description ✏️
- 탐색탭 > 장르,미개봉,품절제외 필터 영역 항상 보이기
- 마켓상세페이지 > 장르,미개봉,품절제외 필터 영역 항상 보이기

## Screenshot 📸
<img width="360" alt="image" src="https://github.com/user-attachments/assets/e3eae6ac-da26-4b6f-80c4-98e061aef35a" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/47a79140-a2bb-49e3-b70c-819b9ff9c419" />

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
비공개 테스트 중 발견된 사항 적용했습니당