### PR TITLE
[FEAT/#362] 마켓 차단 기능 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_circle_block.xml
+++ b/core/designsystem/src/main/res/drawable/ic_circle_block.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,12m-11.81,0a11.81,11.81 0,1 1,23.62 0a11.81,11.81 0,1 1,-23.62 0"
+        android:strokeWidth="0.38"
+        android:fillColor="#ffffff"
+        android:strokeColor="#D9D9D9" />
+    <path
+        android:pathData="M19,12C19,8.134 15.866,5 12,5C8.134,5 5,8.134 5,12C5,15.866 8.134,19 12,19C15.866,19 19,15.866 19,12ZM12,6.4C15.093,6.4 17.6,8.907 17.6,12C17.6,15.093 15.093,17.6 12,17.6C8.907,17.6 6.4,15.093 6.4,12C6.4,8.907 8.907,6.4 12,6.4Z"
+        android:fillColor="#545454"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M16.995,7.995L7.995,16.995L7.005,16.005L16.005,7.005L16.995,7.995Z"
+        android:fillColor="#545454" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_circle_unblock.xml
+++ b/core/designsystem/src/main/res/drawable/ic_circle_unblock.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,12m-11.81,0a11.81,11.81 0,1 1,23.62 0a11.81,11.81 0,1 1,-23.62 0"
+        android:strokeWidth="0.38"
+        android:fillColor="#ffffff"
+        android:strokeColor="#D9D9D9" />
+    <path
+        android:pathData="M19,12C19,8.134 15.866,5 12,5C8.134,5 5,8.134 5,12C5,15.866 8.134,19 12,19C15.866,19 19,15.866 19,12ZM12,6.4C15.093,6.4 17.6,8.907 17.6,12C17.6,15.093 15.093,17.6 12,17.6C8.907,17.6 6.4,15.093 6.4,12C6.4,8.907 8.907,6.4 12,6.4Z"
+        android:fillColor="#545454"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M14,13H10V11H14V13Z"
+        android:fillColor="#545454" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_white_block.xml
+++ b/core/designsystem/src/main/res/drawable/ic_white_block.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+    <path
+        android:pathData="M14,7C14,3.134 10.866,0 7,0C3.134,0 0,3.134 0,7C0,10.866 3.134,14 7,14C10.866,14 14,10.866 14,7ZM7,1.4C10.093,1.4 12.6,3.907 12.6,7C12.6,10.093 10.093,12.6 7,12.6C3.907,12.6 1.4,10.093 1.4,7C1.4,3.907 3.907,1.4 7,1.4Z"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M11.995,2.995L2.995,11.995L2.005,11.005L11.005,2.005L11.995,2.995Z"
+        android:fillColor="#ffffff" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_white_unblock.xml
+++ b/core/designsystem/src/main/res/drawable/ic_white_unblock.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+    <path
+        android:pathData="M14,7C14,3.134 10.866,0 7,0C3.134,0 0,3.134 0,7C0,10.866 3.134,14 7,14C10.866,14 14,10.866 14,7ZM7,1.4C10.093,1.4 12.6,3.907 12.6,7C12.6,10.093 10.093,12.6 7,12.6C3.907,12.6 1.4,10.093 1.4,7C1.4,3.907 3.907,1.4 7,1.4Z"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M9,8H5V6H9V8Z"
+        android:fillColor="#ffffff" />
+</vector>

--- a/data/chat/src/main/java/com/napzak/market/chat/dto/ChatRoomInformationResponse.kt
+++ b/data/chat/src/main/java/com/napzak/market/chat/dto/ChatRoomInformationResponse.kt
@@ -30,5 +30,7 @@ data class ChatRoomInformationResponse(
         @SerialName("storePhoto") val storePhoto: String,
         @SerialName("isWithdrawn") val isWithdrawn: Boolean,
         @SerialName("isReported") val isReported: Boolean,
+        @SerialName("isOpponentStoreBlocked") val isOpponentStoreBlocked: Boolean,
+        @SerialName("isChatBlocked") val isChatBlocked: Boolean,
     )
 }

--- a/data/chat/src/main/java/com/napzak/market/chat/mapper/ChatRoomInformationMapper.kt
+++ b/data/chat/src/main/java/com/napzak/market/chat/mapper/ChatRoomInformationMapper.kt
@@ -30,4 +30,6 @@ private fun ChatRoomInformationResponse.StoreInfo.toDomain(): StoreBrief = Store
     storePhoto = storePhoto,
     isWithdrawn = isWithdrawn,
     isReported = isReported,
+    isOpponentStoreBlocked = isOpponentStoreBlocked,
+    isMyStoreBlocked = isChatBlocked,
 )

--- a/data/chat/src/test/resources/api-response/ChatRoomInformation.json
+++ b/data/chat/src/test/resources/api-response/ChatRoomInformation.json
@@ -19,7 +19,9 @@
       "nickname": "납작한 시나모롤",
       "storePhoto": "https://napzak-dev-bucket.s3.ap-northeast-2.amazonaws.com/store/img_profile_lg.png",
       "isWithdrawn": false,
-      "isReported": false
+      "isReported": false,
+      "isOpponentStoreBlocked": false,
+      "isChatBlocked": false
     },
     "roomId": 6
   }

--- a/data/store/src/main/java/com/napzak/market/store/datasource/StoreDataSource.kt
+++ b/data/store/src/main/java/com/napzak/market/store/datasource/StoreDataSource.kt
@@ -61,4 +61,12 @@ class StoreDataSource @Inject constructor(
     suspend fun postTermsAgreement(bundleId: Int) : EmptyDataResponse{
         return storeService.postTermsAgreement(bundleId)
     }
+
+    suspend fun blockStore(storeId: Long): EmptyDataResponse {
+        return storeService.blockStore(storeId)
+    }
+
+    suspend fun unblockStore(storeId: Long): EmptyDataResponse {
+        return storeService.unblockStore(storeId)
+    }
 }

--- a/data/store/src/main/java/com/napzak/market/store/dto/response/StoreDetailResponse.kt
+++ b/data/store/src/main/java/com/napzak/market/store/dto/response/StoreDetailResponse.kt
@@ -11,6 +11,7 @@ data class StoreDetailResponse(
     @SerialName("storePhoto") val storePhoto: String,
     @SerialName("storeCover") val storeCover: String,
     @SerialName("isStoreOwner") val isStoreOwner: Boolean,
+    @SerialName("isStoreBlocked") val isStoreBlocked: Boolean,
     @SerialName("genrePreferences") val genrePreferences: List<StoreDetailGenreDto>,
 )
 

--- a/data/store/src/main/java/com/napzak/market/store/mapper/StoreDetailMapper.kt
+++ b/data/store/src/main/java/com/napzak/market/store/mapper/StoreDetailMapper.kt
@@ -12,6 +12,7 @@ fun StoreDetailResponse.toDomain(): StoreDetail = StoreDetail(
     photoUrl = storePhoto,
     coverUrl = storeCover,
     isOwner = isStoreOwner,
+    isBlocked = isStoreBlocked,
     genrePreferences = genrePreferences.map { it.toDomain() },
 )
 

--- a/data/store/src/main/java/com/napzak/market/store/repositoryimpl/StoreRepositoryImpl.kt
+++ b/data/store/src/main/java/com/napzak/market/store/repositoryimpl/StoreRepositoryImpl.kt
@@ -66,4 +66,12 @@ class StoreRepositoryImpl @Inject constructor(
     override suspend fun postTermsAgreement(bundleId: Int) : Result<Unit> = runCatching {
         storeDataSource.postTermsAgreement(bundleId)
     }
+
+    override suspend fun blockStore(storeId: Long): Result<Unit> = runCatching {
+        storeDataSource.blockStore(storeId)
+    }
+
+    override suspend fun unblockStore(storeId: Long): Result<Unit> = runCatching {
+        storeDataSource.unblockStore(storeId)
+    }
 }

--- a/data/store/src/main/java/com/napzak/market/store/service/StoreService.kt
+++ b/data/store/src/main/java/com/napzak/market/store/service/StoreService.kt
@@ -65,4 +65,15 @@ interface StoreService {
     suspend fun postTermsAgreement(
         @Path("bundleId") bundleId: Int
     ): EmptyDataResponse
+
+    @POST("stores/block/{storeId}")
+    suspend fun blockStore(
+        @Path("storeId") storeId: Long
+    ): EmptyDataResponse
+
+
+    @POST("stores/unblock/{storeId}")
+    suspend fun unblockStore(
+        @Path("storeId") storeId: Long
+    ): EmptyDataResponse
 }

--- a/domain/chat/src/main/java/com/napzak/market/chat/model/StoreBrief.kt
+++ b/domain/chat/src/main/java/com/napzak/market/chat/model/StoreBrief.kt
@@ -6,4 +6,18 @@ data class StoreBrief(
     val storePhoto: String,
     val isWithdrawn: Boolean,
     val isReported: Boolean,
-)
+    val isOpponentStoreBlocked: Boolean,
+    val isMyStoreBlocked: Boolean,
+) {
+    companion object {
+        fun mock() = StoreBrief(
+            storeId = 1,
+            nickname = "납자기",
+            storePhoto = "",
+            isWithdrawn = false,
+            isReported = false,
+            isOpponentStoreBlocked = false,
+            isMyStoreBlocked = false,
+        )
+    }
+}

--- a/domain/chat/src/main/java/com/napzak/market/chat/model/StoreBrief.kt
+++ b/domain/chat/src/main/java/com/napzak/market/chat/model/StoreBrief.kt
@@ -9,6 +9,8 @@ data class StoreBrief(
     val isOpponentStoreBlocked: Boolean,
     val isMyStoreBlocked: Boolean,
 ) {
+    val isChatBlocked get() = isOpponentStoreBlocked || isMyStoreBlocked
+
     companion object {
         fun mock() = StoreBrief(
             storeId = 1,

--- a/domain/store/src/main/java/com/napzak/market/store/model/StoreDetail.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/model/StoreDetail.kt
@@ -7,6 +7,7 @@ data class StoreDetail(
     val photoUrl: String,
     val coverUrl: String,
     val isOwner: Boolean,
+    val isBlocked: Boolean,
     val genrePreferences: List<StoreDetailGenre>,
 ) {
     // TODO: 삭제해야 함
@@ -18,6 +19,7 @@ data class StoreDetail(
             photoUrl = "",
             coverUrl = "",
             isOwner = true,
+            isBlocked = false,
             genrePreferences = listOf(
                 StoreDetailGenre(0, "산리오0"),
                 StoreDetailGenre(1, "산리오1"),

--- a/domain/store/src/main/java/com/napzak/market/store/repository/StoreRepository.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/repository/StoreRepository.kt
@@ -1,12 +1,11 @@
 package com.napzak.market.store.repository
 
 import com.napzak.market.store.model.Genre
-import com.napzak.market.store.model.KakaoLogin
-import com.napzak.market.store.model.UserWithdrawal
 import com.napzak.market.store.model.StoreDetail
 import com.napzak.market.store.model.StoreEditProfile
 import com.napzak.market.store.model.StoreInfo
 import com.napzak.market.store.model.TermsAgreement
+import com.napzak.market.store.model.UserWithdrawal
 
 interface StoreRepository {
     suspend fun getValidateNickname(nickname: String): Result<Unit>
@@ -30,4 +29,8 @@ interface StoreRepository {
     suspend fun getTermsAgreement() : Result<TermsAgreement>
 
     suspend fun postTermsAgreement(bundleId: Int): Result<Unit>
+
+    suspend fun blockStore(storeId: Long): Result<Unit>
+
+    suspend fun unblockStore(storeId: Long): Result<Unit>
 }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
@@ -271,7 +271,8 @@ internal fun ChatRoomScreen(
                         }
                         ChatRoomInputField(
                             text = chat,
-                            enabled = !chatRoomState.isChatDisabled,
+                            enabled = !chatRoomState.isChatDisabled
+                                    && chatRoom.storeBrief?.isChatBlocked == false,
                             onSendClick = onSendChatClick,
                             onTextChange = onChatChange,
                             onPhotoSelect = {

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
@@ -46,17 +46,22 @@ import com.napzak.market.chat.chatroom.component.ChatRoomProductSection
 import com.napzak.market.chat.chatroom.component.ChatRoomTopBar
 import com.napzak.market.chat.chatroom.preview.mockChatRoom
 import com.napzak.market.chat.chatroom.preview.mockChats
+import com.napzak.market.chat.chatroom.state.ChatRoomPopupEvent
+import com.napzak.market.chat.chatroom.state.ChatRoomPopupState
 import com.napzak.market.chat.model.ReceiveMessage
 import com.napzak.market.common.state.UiState
 import com.napzak.market.designsystem.R.drawable.ic_no_chatting_history
+import com.napzak.market.designsystem.R.drawable.ic_white_block
+import com.napzak.market.designsystem.R.drawable.ic_white_unblock
 import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
-import com.napzak.market.designsystem.component.toast.ToastFontType
 import com.napzak.market.designsystem.component.toast.ToastType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.chat.R.drawable.img_user_blocked_popup
 import com.napzak.market.feature.chat.R.string.chat_room_empty_guide_1
 import com.napzak.market.feature.chat.R.string.chat_room_empty_guide_2
+import com.napzak.market.feature.chat.R.string.chat_room_toast_block
+import com.napzak.market.feature.chat.R.string.chat_room_toast_unblock
 import com.napzak.market.ui_util.ScreenPreview
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -122,9 +127,20 @@ internal fun ChatRoomRoute(
                     is ChatRoomSideEffect.ShowToast -> toast.makeText(
                         toastType = ToastType.COMMON,
                         message = sideEffect.message,
-                        fontType = ToastFontType.SMALL,
                         yOffset = toast.toastOffsetWithBottomBar(),
                     )
+
+                    is ChatRoomSideEffect.OnChangeBlockState -> {
+                        val (message, icon) =
+                            if (sideEffect.newState) chat_room_toast_block to ic_white_block
+                            else chat_room_toast_unblock to ic_white_unblock
+                        toast.makeText(
+                            toastType = ToastType.COMMON,
+                            message = context.getString(message),
+                            icon = icon,
+                            yOffset = toast.toastOffsetWithBottomBar(),
+                        )
+                    }
                 }
             }
     }
@@ -140,7 +156,8 @@ internal fun ChatRoomRoute(
             viewModel.trackReportMarket()
             onStoreReportNavigate(productId)
         },
-        onBlockClick = {}, // TODO: 차단 함수 연결
+        onBlockClick = { viewModel.toggleStoreBlockState(true) },
+        onUnblockClick = { viewModel.toggleStoreBlockState(false) },
         onWithdrawChatRoomClick = viewModel::withdrawChatRoom,
         onNavigateUp = onNavigateUp,
         onSendChatClick = viewModel::sendTextMessage,
@@ -159,6 +176,7 @@ internal fun ChatRoomScreen(
     onProductDetailClick: (Long) -> Unit,
     onReportClick: (Long) -> Unit,
     onBlockClick: () -> Unit,
+    onUnblockClick: () -> Unit,
     onWithdrawChatRoomClick: () -> Unit,
     onNavigateUp: () -> Unit,
     onSendChatClick: (String) -> Unit,
@@ -172,22 +190,11 @@ internal fun ChatRoomScreen(
 
         is UiState.Success -> {
             val chatRoom = chatRoomState.chatRoomState.data
-            var isBottomSheetVisible by remember { mutableStateOf(false) }
-            var isWithdrawDialogVisible by remember { mutableStateOf(false) }
-            var isBlockDialogVisible by remember { mutableStateOf(false) }
-            var isPreviewVisible by remember { mutableStateOf(false) }
-            var selectedImageUrl: String? by remember { mutableStateOf(null) }
-
-            ChatRoomDialogSection(
-                isWithdrawDialogVisible = isWithdrawDialogVisible,
-                isBlockDialogVisible = isBlockDialogVisible,
-                onWithdrawConfirm = onWithdrawChatRoomClick,
-                onBlockConfirm = onBlockClick,
-                onDismissClick = {
-                    isWithdrawDialogVisible = false
-                    isBlockDialogVisible = false
-                },
-            )
+            var selectedImageUrl by remember { mutableStateOf<String?>(null) }
+            var popupState by remember { mutableStateOf(ChatRoomPopupState()) }
+            fun updatePopupState(event: ChatRoomPopupEvent) {
+                popupState = popupState.handleEvent(event)
+            }
 
             Column(
                 modifier = modifier
@@ -197,7 +204,7 @@ internal fun ChatRoomScreen(
                 ChatRoomTopBar(
                     storeName = chatRoom.storeBrief?.nickname ?: "",
                     onBackClick = onNavigateUp,
-                    onMenuClick = { isBottomSheetVisible = true },
+                    onMenuClick = { updatePopupState(ChatRoomPopupEvent.ShowBottomSheet) },
                 )
 
                 chatRoom.productBrief?.let { product ->
@@ -269,7 +276,7 @@ internal fun ChatRoomScreen(
                             onTextChange = onChatChange,
                             onPhotoSelect = {
                                 selectedImageUrl = it
-                                isPreviewVisible = true
+                                updatePopupState(ChatRoomPopupEvent.ShowPreview)
                             },
                         )
                     }
@@ -280,28 +287,52 @@ internal fun ChatRoomScreen(
             selectedImageUrl?.let {
                 ChatImageZoomScreen(
                     selectedImageUrl = it,
-                    isPreview = isPreviewVisible,
+                    isPreview = popupState.isPreviewVisible,
                     onBackClick = {
                         selectedImageUrl = null
-                        isPreviewVisible = false
+                        updatePopupState(ChatRoomPopupEvent.DismissPreview)
                     },
                     onSendClick = {
                         selectedImageUrl?.let(onPhotoSelect)
                         selectedImageUrl = null
-                        isPreviewVisible = false
+                        updatePopupState(ChatRoomPopupEvent.DismissPreview)
                     },
                 )
             }
 
-
-            if (isBottomSheetVisible) {
-                ChatRoomBottomSheet(
-                    onReportClick = { chatRoom.storeBrief?.storeId?.let(onReportClick) },
-                    onBlockClick = { isBlockDialogVisible = true },
-                    onExitClick = { isWithdrawDialogVisible = true },
-                    onDismissRequest = { isBottomSheetVisible = false },
-                )
+            if (popupState.isBottomSheetVisible) {
+                chatRoom.storeBrief?.let { store ->
+                    ChatRoomBottomSheet(
+                        isStoreBlocked = store.isOpponentStoreBlocked,
+                        onReportClick = { store.storeId.let(onReportClick) },
+                        onBlockClick = {
+                            if (store.isOpponentStoreBlocked) {
+                                onUnblockClick()
+                                updatePopupState(ChatRoomPopupEvent.DismissBottomSheet)
+                            } else {
+                                updatePopupState(ChatRoomPopupEvent.ShowBlockDialog)
+                            }
+                        },
+                        onExitClick = {
+                            updatePopupState(ChatRoomPopupEvent.ShowWithdrawDialog)
+                        },
+                        onDismissRequest = {
+                            updatePopupState(ChatRoomPopupEvent.DismissBottomSheet)
+                        },
+                    )
+                }
             }
+
+            ChatRoomDialogSection(
+                isWithdrawDialogVisible = popupState.isWithdrawDialogVisible,
+                isBlockDialogVisible = popupState.isBlockDialogVisible,
+                onWithdrawConfirm = onWithdrawChatRoomClick,
+                onBlockConfirm = {
+                    onBlockClick()
+                    updatePopupState(ChatRoomPopupEvent.DismissOnBlockConfirmed)
+                },
+                onDismissClick = ::updatePopupState,
+            )
         }
 
         else -> {
@@ -359,6 +390,7 @@ private fun ChatRoomScreenPreview() {
             onProductDetailClick = {},
             onReportClick = {},
             onBlockClick = {},
+            onUnblockClick = {},
             onWithdrawChatRoomClick = {},
             onNavigateUp = {},
             onPhotoSelect = {},
@@ -380,6 +412,7 @@ private fun ChatRoomScreenEmptyPreview() {
             onProductDetailClick = {},
             onReportClick = {},
             onBlockClick = {},
+            onUnblockClick = {},
             onWithdrawChatRoomClick = {},
             onNavigateUp = {},
             onPhotoSelect = {},

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
@@ -39,11 +39,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.napzak.market.chat.chatroom.component.ChatImageZoomScreen
 import com.napzak.market.chat.chatroom.component.ChatRoomBottomSheet
+import com.napzak.market.chat.chatroom.component.ChatRoomDialogSection
 import com.napzak.market.chat.chatroom.component.ChatRoomInputField
 import com.napzak.market.chat.chatroom.component.ChatRoomItemColumn
 import com.napzak.market.chat.chatroom.component.ChatRoomProductSection
 import com.napzak.market.chat.chatroom.component.ChatRoomTopBar
-import com.napzak.market.chat.chatroom.component.NapzakWithdrawDialog
 import com.napzak.market.chat.chatroom.preview.mockChatRoom
 import com.napzak.market.chat.chatroom.preview.mockChats
 import com.napzak.market.chat.model.ReceiveMessage
@@ -140,7 +140,8 @@ internal fun ChatRoomRoute(
             viewModel.trackReportMarket()
             onStoreReportNavigate(productId)
         },
-        onExitChatRoomClick = viewModel::withdrawChatRoom,
+        onBlockClick = {}, // TODO: 차단 함수 연결
+        onWithdrawChatRoomClick = viewModel::withdrawChatRoom,
         onNavigateUp = onNavigateUp,
         onSendChatClick = viewModel::sendTextMessage,
         onPhotoSelect = viewModel::sendImageMessage,
@@ -157,7 +158,8 @@ internal fun ChatRoomScreen(
     onChatChange: (String) -> Unit,
     onProductDetailClick: (Long) -> Unit,
     onReportClick: (Long) -> Unit,
-    onExitChatRoomClick: () -> Unit,
+    onBlockClick: () -> Unit,
+    onWithdrawChatRoomClick: () -> Unit,
     onNavigateUp: () -> Unit,
     onSendChatClick: (String) -> Unit,
     onPhotoSelect: (String) -> Unit,
@@ -172,15 +174,21 @@ internal fun ChatRoomScreen(
             val chatRoom = chatRoomState.chatRoomState.data
             var isBottomSheetVisible by remember { mutableStateOf(false) }
             var isWithdrawDialogVisible by remember { mutableStateOf(false) }
+            var isBlockDialogVisible by remember { mutableStateOf(false) }
             var isPreviewVisible by remember { mutableStateOf(false) }
             var selectedImageUrl: String? by remember { mutableStateOf(null) }
 
-            if (isWithdrawDialogVisible) {
-                NapzakWithdrawDialog(
-                    onConfirmClick = { onExitChatRoomClick() },
-                    onDismissClick = { isWithdrawDialogVisible = false },
-                )
-            }
+            ChatRoomDialogSection(
+                isWithdrawDialogVisible = isWithdrawDialogVisible,
+                isBlockDialogVisible = isBlockDialogVisible,
+                onWithdrawConfirm = onWithdrawChatRoomClick,
+                onBlockConfirm = onBlockClick,
+                onDismissClick = {
+                    isWithdrawDialogVisible = false
+                    isBlockDialogVisible = false
+                },
+            )
+
             Column(
                 modifier = modifier
                     .fillMaxSize()
@@ -289,6 +297,7 @@ internal fun ChatRoomScreen(
             if (isBottomSheetVisible) {
                 ChatRoomBottomSheet(
                     onReportClick = { chatRoom.storeBrief?.storeId?.let(onReportClick) },
+                    onBlockClick = { isBlockDialogVisible = true },
                     onExitClick = { isWithdrawDialogVisible = true },
                     onDismissRequest = { isBottomSheetVisible = false },
                 )
@@ -349,7 +358,8 @@ private fun ChatRoomScreenPreview() {
             onSendChatClick = {},
             onProductDetailClick = {},
             onReportClick = {},
-            onExitChatRoomClick = {},
+            onBlockClick = {},
+            onWithdrawChatRoomClick = {},
             onNavigateUp = {},
             onPhotoSelect = {},
             chatRoomState = ChatRoomUiState(UiState.Success(mockChatRoom)),
@@ -369,7 +379,8 @@ private fun ChatRoomScreenEmptyPreview() {
             onSendChatClick = {},
             onProductDetailClick = {},
             onReportClick = {},
-            onExitChatRoomClick = {},
+            onBlockClick = {},
+            onWithdrawChatRoomClick = {},
             onNavigateUp = {},
             onPhotoSelect = {},
             chatRoomState = ChatRoomUiState(UiState.Success(mockChatRoom)),

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomScreen.kt
@@ -138,7 +138,7 @@ internal fun ChatRoomRoute(
                             toastType = ToastType.COMMON,
                             message = context.getString(message),
                             icon = icon,
-                            yOffset = toast.toastOffsetWithBottomBar(),
+                            yOffset = 200,
                         )
                     }
                 }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomSideEffect.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/ChatRoomSideEffect.kt
@@ -6,4 +6,5 @@ sealed interface ChatRoomSideEffect {
     data object OnWithdrawChatRoom : ChatRoomSideEffect
     data class ShowToast(val message: String) : ChatRoomSideEffect
     data object OnErrorOccurred : ChatRoomSideEffect
+    data class OnChangeBlockState(val newState: Boolean) : ChatRoomSideEffect
 }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomBottomSheet.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomBottomSheet.kt
@@ -2,6 +2,7 @@ package com.napzak.market.chat.chatroom.component
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -12,11 +13,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.napzak.market.designsystem.R.drawable.ic_circle_block
 import com.napzak.market.designsystem.R.drawable.ic_circle_error
 import com.napzak.market.designsystem.R.drawable.ic_circle_exit
 import com.napzak.market.designsystem.component.bottomsheet.BottomSheetMenuItem
 import com.napzak.market.designsystem.component.bottomsheet.DragHandleBottomSheet
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_block
 import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_exit
 import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_report
 
@@ -24,6 +27,7 @@ import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_report
 @Composable
 internal fun ChatRoomBottomSheet(
     onReportClick: () -> Unit,
+    onBlockClick: () -> Unit,
     onExitClick: () -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
@@ -33,13 +37,21 @@ internal fun ChatRoomBottomSheet(
     DragHandleBottomSheet(
         sheetState = sheetState,
         onDismissRequest = onDismissRequest,
-        modifier = modifier.height(140.dp),
+        modifier = modifier
+            .padding(bottom = 28.dp),
     ) {
         BottomSheetMenuItem(
             menuIcon = ImageVector.vectorResource(ic_circle_error),
             menuName = stringResource(chat_room_bottom_sheet_report),
             onItemClick = onReportClick,
             textColor = NapzakMarketTheme.colors.red,
+        )
+        Spacer(Modifier.height(20.dp))
+        BottomSheetMenuItem(
+            menuIcon = ImageVector.vectorResource(ic_circle_block),
+            menuName = stringResource(chat_room_bottom_sheet_block),
+            onItemClick = onBlockClick,
+            textColor = NapzakMarketTheme.colors.gray400,
         )
         Spacer(Modifier.height(20.dp))
         BottomSheetMenuItem(
@@ -57,6 +69,7 @@ private fun ProductBottomSheetPreview() {
     NapzakMarketTheme {
         ChatRoomBottomSheet(
             onReportClick = { },
+            onBlockClick = { },
             onExitClick = { },
             onDismissRequest = { },
             modifier = Modifier.wrapContentHeight(),

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomBottomSheet.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomBottomSheet.kt
@@ -16,16 +16,19 @@ import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R.drawable.ic_circle_block
 import com.napzak.market.designsystem.R.drawable.ic_circle_error
 import com.napzak.market.designsystem.R.drawable.ic_circle_exit
+import com.napzak.market.designsystem.R.drawable.ic_circle_unblock
 import com.napzak.market.designsystem.component.bottomsheet.BottomSheetMenuItem
 import com.napzak.market.designsystem.component.bottomsheet.DragHandleBottomSheet
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_block
 import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_exit
 import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_report
+import com.napzak.market.feature.chat.R.string.chat_room_bottom_sheet_unblock
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ChatRoomBottomSheet(
+    isStoreBlocked: Boolean,
     onReportClick: () -> Unit,
     onBlockClick: () -> Unit,
     onExitClick: () -> Unit,
@@ -33,6 +36,10 @@ internal fun ChatRoomBottomSheet(
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState()
+
+    val (blockMessageResId, blockIconResId) =
+        if (isStoreBlocked) chat_room_bottom_sheet_unblock to ic_circle_unblock
+        else chat_room_bottom_sheet_block to ic_circle_block
 
     DragHandleBottomSheet(
         sheetState = sheetState,
@@ -48,8 +55,8 @@ internal fun ChatRoomBottomSheet(
         )
         Spacer(Modifier.height(20.dp))
         BottomSheetMenuItem(
-            menuIcon = ImageVector.vectorResource(ic_circle_block),
-            menuName = stringResource(chat_room_bottom_sheet_block),
+            menuIcon = ImageVector.vectorResource(blockIconResId),
+            menuName = stringResource(blockMessageResId),
             onItemClick = onBlockClick,
             textColor = NapzakMarketTheme.colors.gray400,
         )
@@ -68,6 +75,7 @@ internal fun ChatRoomBottomSheet(
 private fun ProductBottomSheetPreview() {
     NapzakMarketTheme {
         ChatRoomBottomSheet(
+            isStoreBlocked = false,
             onReportClick = { },
             onBlockClick = { },
             onExitClick = { },

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomWithdrawDialog.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomWithdrawDialog.kt
@@ -3,6 +3,7 @@ package com.napzak.market.chat.chatroom.component
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.napzak.market.chat.chatroom.state.ChatRoomPopupEvent
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
 import com.napzak.market.designsystem.component.dialog.NapzakDialogDefault
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
@@ -21,7 +22,7 @@ internal fun ChatRoomDialogSection(
     isBlockDialogVisible: Boolean,
     onWithdrawConfirm: () -> Unit,
     onBlockConfirm: () -> Unit,
-    onDismissClick: () -> Unit,
+    onDismissClick: (ChatRoomPopupEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (isWithdrawDialogVisible) {
@@ -31,7 +32,7 @@ internal fun ChatRoomDialogSection(
             confirmText = stringResource(chat_room_withdraw_dialog_confirm),
             dismissText = stringResource(chat_room_withdraw_dialog_cancel),
             onConfirmClick = onWithdrawConfirm,
-            onDismissClick = onDismissClick,
+            onDismissClick = { onDismissClick(ChatRoomPopupEvent.DismissWithdrawDialog) },
             dialogColor = NapzakDialogDefault.color.copy(
                 titleColor = NapzakMarketTheme.colors.black,
             ),
@@ -46,7 +47,7 @@ internal fun ChatRoomDialogSection(
             confirmText = stringResource(chat_room_block_dialog_confirm),
             dismissText = stringResource(chat_room_block_dialog_cancel),
             onConfirmClick = onBlockConfirm,
-            onDismissClick = onDismissClick,
+            onDismissClick = { onDismissClick(ChatRoomPopupEvent.DismissBlockDialog) },
             dialogColor = NapzakDialogDefault.color.copy(
                 titleColor = NapzakMarketTheme.colors.black,
             ),

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomWithdrawDialog.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/component/ChatRoomWithdrawDialog.kt
@@ -6,39 +6,51 @@ import androidx.compose.ui.res.stringResource
 import com.napzak.market.designsystem.component.dialog.NapzakDialog
 import com.napzak.market.designsystem.component.dialog.NapzakDialogDefault
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.chat.R.string.chat_room_block_dialog_cancel
+import com.napzak.market.feature.chat.R.string.chat_room_block_dialog_confirm
+import com.napzak.market.feature.chat.R.string.chat_room_block_dialog_content
+import com.napzak.market.feature.chat.R.string.chat_room_block_dialog_title
 import com.napzak.market.feature.chat.R.string.chat_room_withdraw_dialog_cancel
 import com.napzak.market.feature.chat.R.string.chat_room_withdraw_dialog_confirm
 import com.napzak.market.feature.chat.R.string.chat_room_withdraw_dialog_content
 import com.napzak.market.feature.chat.R.string.chat_room_withdraw_dialog_title
-import com.napzak.market.ui_util.ScreenPreview
 
 @Composable
-internal fun NapzakWithdrawDialog(
-    onConfirmClick: () -> Unit,
+internal fun ChatRoomDialogSection(
+    isWithdrawDialogVisible: Boolean,
+    isBlockDialogVisible: Boolean,
+    onWithdrawConfirm: () -> Unit,
+    onBlockConfirm: () -> Unit,
     onDismissClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    NapzakDialog(
-        title = stringResource(chat_room_withdraw_dialog_title),
-        subTitle = stringResource(chat_room_withdraw_dialog_content),
-        confirmText = stringResource(chat_room_withdraw_dialog_confirm),
-        dismissText = stringResource(chat_room_withdraw_dialog_cancel),
-        onConfirmClick = onConfirmClick,
-        onDismissClick = onDismissClick,
-        dialogColor = NapzakDialogDefault.color.copy(
-            titleColor = NapzakMarketTheme.colors.black,
-        ),
-        modifier = modifier,
-    )
-}
+    if (isWithdrawDialogVisible) {
+        NapzakDialog(
+            title = stringResource(chat_room_withdraw_dialog_title),
+            subTitle = stringResource(chat_room_withdraw_dialog_content),
+            confirmText = stringResource(chat_room_withdraw_dialog_confirm),
+            dismissText = stringResource(chat_room_withdraw_dialog_cancel),
+            onConfirmClick = onWithdrawConfirm,
+            onDismissClick = onDismissClick,
+            dialogColor = NapzakDialogDefault.color.copy(
+                titleColor = NapzakMarketTheme.colors.black,
+            ),
+            modifier = modifier,
+        )
+    }
 
-@ScreenPreview()
-@Composable
-private fun NapzakWithdrawDialogPreview() {
-    NapzakMarketTheme {
-        NapzakWithdrawDialog(
-            onConfirmClick = {},
-            onDismissClick = {},
+    if (isBlockDialogVisible) {
+        NapzakDialog(
+            title = stringResource(chat_room_block_dialog_title),
+            subTitle = stringResource(chat_room_block_dialog_content),
+            confirmText = stringResource(chat_room_block_dialog_confirm),
+            dismissText = stringResource(chat_room_block_dialog_cancel),
+            onConfirmClick = onBlockConfirm,
+            onDismissClick = onDismissClick,
+            dialogColor = NapzakDialogDefault.color.copy(
+                titleColor = NapzakMarketTheme.colors.black,
+            ),
+            modifier = modifier,
         )
     }
 }

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/preview/MockChats.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/preview/MockChats.kt
@@ -157,16 +157,9 @@ internal val mockProductBrief
         isProductDeleted = false
     )
 
-internal val mockStoreBrief = StoreBrief(
-    storeId = 1,
-    nickname = "납자기",
-    storePhoto = "",
-    isWithdrawn = false,
-    isReported = false,
-)
 
 internal val mockChatRoom = ChatRoomState(
     roomId = 1,
     productBrief = mockProductBrief,
-    storeBrief = mockStoreBrief
+    storeBrief = StoreBrief.mock()
 )

--- a/feature/chat/src/main/java/com/napzak/market/chat/chatroom/state/ChatRoomPopupState.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/chatroom/state/ChatRoomPopupState.kt
@@ -1,0 +1,39 @@
+package com.napzak.market.chat.chatroom.state
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+internal data class ChatRoomPopupState(
+    val isBottomSheetVisible: Boolean = false,
+    val isWithdrawDialogVisible: Boolean = false,
+    val isBlockDialogVisible: Boolean = false,
+    val isPreviewVisible: Boolean = false,
+) {
+    fun handleEvent(event: ChatRoomPopupEvent): ChatRoomPopupState = when (event) {
+        is ChatRoomPopupEvent.ShowBottomSheet -> copy(isBottomSheetVisible = true)
+        is ChatRoomPopupEvent.DismissBottomSheet -> copy(isBottomSheetVisible = false)
+        is ChatRoomPopupEvent.ShowWithdrawDialog -> copy(isWithdrawDialogVisible = true)
+        is ChatRoomPopupEvent.DismissWithdrawDialog -> copy(isWithdrawDialogVisible = false)
+        is ChatRoomPopupEvent.ShowBlockDialog -> copy(isBlockDialogVisible = true)
+        is ChatRoomPopupEvent.DismissBlockDialog -> copy(isBlockDialogVisible = false)
+        is ChatRoomPopupEvent.DismissOnBlockConfirmed -> copy(
+            isBlockDialogVisible = false,
+            isBottomSheetVisible = false,
+        )
+
+        is ChatRoomPopupEvent.ShowPreview -> copy(isPreviewVisible = true)
+        is ChatRoomPopupEvent.DismissPreview -> copy(isPreviewVisible = false)
+    }
+}
+
+internal sealed class ChatRoomPopupEvent() {
+    data object ShowBottomSheet : ChatRoomPopupEvent()
+    data object DismissBottomSheet : ChatRoomPopupEvent()
+    data object ShowWithdrawDialog : ChatRoomPopupEvent()
+    data object DismissWithdrawDialog : ChatRoomPopupEvent()
+    data object ShowBlockDialog : ChatRoomPopupEvent()
+    data object DismissBlockDialog : ChatRoomPopupEvent()
+    data object DismissOnBlockConfirmed : ChatRoomPopupEvent()
+    data object ShowPreview : ChatRoomPopupEvent()
+    data object DismissPreview : ChatRoomPopupEvent()
+}

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -13,7 +13,10 @@
 
     <string name="chat_room_bottom_sheet_report">마켓 신고하기</string>
     <string name="chat_room_bottom_sheet_block">마켓 차단하기</string>
+    <string name="chat_room_bottom_sheet_unblock">마켓 차단 해제하기</string>
     <string name="chat_room_bottom_sheet_exit">채팅방 나가기</string>
+    <string name="chat_room_toast_block">마켓을 차단했어요.</string>
+    <string name="chat_room_toast_unblock">마켓 차단을 해제했어요.</string>
 
     <string name="chat_room_product_title_sell_received">팔아요 상품 문의가 도착했어요!</string>
     <string name="chat_room_product_title_buy_received">구해요 상품 문의가 도착했어요!</string>

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
 
     <string name="chat_room_bottom_sheet_report">마켓 신고하기</string>
+    <string name="chat_room_bottom_sheet_block">마켓 차단하기</string>
     <string name="chat_room_bottom_sheet_exit">채팅방 나가기</string>
 
     <string name="chat_room_product_title_sell_received">팔아요 상품 문의가 도착했어요!</string>
@@ -31,8 +32,13 @@
 
     <string name="chat_room_withdraw_dialog_title">채팅방 나가기</string>
     <string name="chat_room_withdraw_dialog_content">채팅방에서 나가시겠어요? 나가기를 하면\n더이상 상대방과 대화할 수 없습니다.</string>
+    <string name="chat_room_block_dialog_title">마켓을 차단하시겠어요?</string>
+    <string name="chat_room_block_dialog_content">차단하면 해당 마켓과 대화할 수 없어요.</string>
+
     <string name="chat_room_withdraw_dialog_confirm">나가기</string>
     <string name="chat_room_withdraw_dialog_cancel">취소</string>
+    <string name="chat_room_block_dialog_confirm">예</string>
+    <string name="chat_room_block_dialog_cancel">아니오</string>
 
     <string name="permission_modal_system_setting_off_title">기기 알림이 꺼져있어요!</string>
     <string name="permission_modal_app_setting_off_title">앱 내 알림이 꺼져있어요!</string>

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
@@ -116,6 +116,18 @@ internal fun StoreRoute(
             viewModel.updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
             onStoreReportNavigate(viewModel.storeId)
         },
+        onStoreBlockButtonClick = {
+            viewModel.updateStoreBlockDialogVisibility(true)
+        },
+        onStoreBlockConfirm = {
+            with(viewModel) {
+                updateStoreBlockDialogVisibility(false)
+                updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
+            }
+        },
+        onStoreBlockDismiss = {
+            viewModel.updateStoreBlockDialogVisibility(false)
+        },
         modifier = modifier,
     )
 }
@@ -139,6 +151,9 @@ private fun StoreScreen(
     onProductItemClick: (Long) -> Unit,
     onLikeButtonClick: (Long, Boolean) -> Unit,
     onStoreReportButtonClick: () -> Unit,
+    onStoreBlockButtonClick: () -> Unit,
+    onStoreBlockConfirm: () -> Unit,
+    onStoreBlockDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (uiState.isLoaded) {
@@ -174,6 +189,9 @@ private fun StoreScreen(
                     onLikeButtonClick = onLikeButtonClick,
                     onMenuButtonClick = onMenuButtonClick,
                     onStoreReportButtonClick = onStoreReportButtonClick,
+                    onStoreBlockButtonClick = onStoreBlockButtonClick,
+                    onStoreBlockConfirm = onStoreBlockConfirm,
+                    onStoreBlockDismiss = onStoreBlockDismiss,
                     modifier = modifier,
                 )
             }
@@ -207,6 +225,9 @@ private fun StoreSuccessScreen(
     onLikeButtonClick: (Long, Boolean) -> Unit,
     onMenuButtonClick: () -> Unit,
     onStoreReportButtonClick: () -> Unit,
+    onStoreBlockButtonClick: () -> Unit,
+    onStoreBlockConfirm: () -> Unit,
+    onStoreBlockDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState(
@@ -255,6 +276,9 @@ private fun StoreSuccessScreen(
         onTextChange = onGenreBottomSheetTextChange,
         onGenreSelectButtonClick = onGenreSelectButtonClick,
         onStoreReportButtonClick = onStoreReportButtonClick,
+        onStoreBlockButtonClick = onStoreBlockButtonClick,
+        onStoreBlockConfirm = onStoreBlockConfirm,
+        onStoreBlockDismiss = onStoreBlockDismiss,
     )
 }
 
@@ -286,6 +310,9 @@ private fun StoreScreenPreview(modifier: Modifier = Modifier) {
             onProductItemClick = {},
             onLikeButtonClick = { id, value -> },
             onStoreReportButtonClick = {},
+            onStoreBlockButtonClick = {},
+            onStoreBlockConfirm = {},
+            onStoreBlockDismiss = {},
             modifier = modifier,
         )
     }

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
@@ -83,7 +83,6 @@ internal fun StoreRoute(
                             if (sideEffect.isStoreBlocked) store_toast_block to ic_white_block
                             else store_toast_unblock to ic_white_unblock
 
-
                         toast.makeText(
                             toastType = ToastType.COMMON,
                             message = context.getString(message),

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreScreen.kt
@@ -20,11 +20,15 @@ import com.napzak.market.common.state.UiState
 import com.napzak.market.common.type.BottomSheetType
 import com.napzak.market.common.type.MarketTab
 import com.napzak.market.common.type.SortType
+import com.napzak.market.designsystem.R.drawable.ic_white_block
+import com.napzak.market.designsystem.R.drawable.ic_white_unblock
 import com.napzak.market.designsystem.R.string.heart_click_snackbar_message
 import com.napzak.market.designsystem.component.loading.NapzakLoadingOverlay
 import com.napzak.market.designsystem.component.toast.LocalNapzakToast
 import com.napzak.market.designsystem.component.toast.ToastType
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.store.R.string.store_toast_block
+import com.napzak.market.feature.store.R.string.store_toast_unblock
 import com.napzak.market.genre.model.Genre
 import com.napzak.market.product.model.Product
 import com.napzak.market.store.model.StoreDetail
@@ -70,7 +74,21 @@ internal fun StoreRoute(
                         toast.makeText(
                             toastType = ToastType.HEART,
                             message = context.getString(heart_click_snackbar_message),
-                            yOffset = 20,
+                            yOffset = 100,
+                        )
+                    }
+
+                    is StoreSideEffect.ShowBlockToast -> {
+                        val (message, icon) =
+                            if (sideEffect.isStoreBlocked) store_toast_block to ic_white_block
+                            else store_toast_unblock to ic_white_unblock
+
+
+                        toast.makeText(
+                            toastType = ToastType.COMMON,
+                            message = context.getString(message),
+                            icon = icon,
+                            yOffset = 100,
                         )
                     }
 
@@ -116,15 +134,11 @@ internal fun StoreRoute(
             viewModel.updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
             onStoreReportNavigate(viewModel.storeId)
         },
-        onStoreBlockButtonClick = {
-            viewModel.updateStoreBlockDialogVisibility(true)
+        onStoreBlockButtonClick = { isStoreBlocked ->
+            if (isStoreBlocked) viewModel.toggleStoreBlockState(isStoreBlocked)
+            else viewModel.updateStoreBlockDialogVisibility(true)
         },
-        onStoreBlockConfirm = {
-            with(viewModel) {
-                updateStoreBlockDialogVisibility(false)
-                updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
-            }
-        },
+        onStoreBlockConfirm = viewModel::toggleStoreBlockState,
         onStoreBlockDismiss = {
             viewModel.updateStoreBlockDialogVisibility(false)
         },
@@ -151,8 +165,8 @@ private fun StoreScreen(
     onProductItemClick: (Long) -> Unit,
     onLikeButtonClick: (Long, Boolean) -> Unit,
     onStoreReportButtonClick: () -> Unit,
-    onStoreBlockButtonClick: () -> Unit,
-    onStoreBlockConfirm: () -> Unit,
+    onStoreBlockButtonClick: (Boolean) -> Unit,
+    onStoreBlockConfirm: (Boolean) -> Unit,
     onStoreBlockDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -225,8 +239,8 @@ private fun StoreSuccessScreen(
     onLikeButtonClick: (Long, Boolean) -> Unit,
     onMenuButtonClick: () -> Unit,
     onStoreReportButtonClick: () -> Unit,
-    onStoreBlockButtonClick: () -> Unit,
-    onStoreBlockConfirm: () -> Unit,
+    onStoreBlockButtonClick: (Boolean) -> Unit,
+    onStoreBlockConfirm: (Boolean) -> Unit,
     onStoreBlockDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -271,13 +285,14 @@ private fun StoreSuccessScreen(
         selectedGenres = filteredGenres,
         genreItems = genreItems,
         sortType = sortType,
+        isStoreBlocked = storeDetail.isBlocked,
         onDismissRequest = onDismissRequest,
         onSortItemClick = onSortItemClick,
         onTextChange = onGenreBottomSheetTextChange,
         onGenreSelectButtonClick = onGenreSelectButtonClick,
         onStoreReportButtonClick = onStoreReportButtonClick,
-        onStoreBlockButtonClick = onStoreBlockButtonClick,
-        onStoreBlockConfirm = onStoreBlockConfirm,
+        onStoreBlockButtonClick = { onStoreBlockButtonClick(storeDetail.isBlocked) },
+        onStoreBlockConfirm = { onStoreBlockConfirm(storeDetail.isBlocked) },
         onStoreBlockDismiss = onStoreBlockDismiss,
     )
 }

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreSideEffect.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreSideEffect.kt
@@ -2,5 +2,6 @@ package com.napzak.market.store.store
 
 sealed interface StoreSideEffect {
     data object ShowHeartToast : StoreSideEffect
+    data class ShowBlockToast(val isStoreBlocked: Boolean) : StoreSideEffect
     data object CancelToast : StoreSideEffect
 }

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
@@ -173,6 +173,12 @@ class StoreViewModel @Inject constructor(
         }
     }
 
+    fun updateStoreBlockDialogVisibility(isVisible: Boolean) {
+        _bottomSheetState.update {
+            it.copy(isStoreBlockDialogVisible = isVisible)
+        }
+    }
+
     fun updateGenreItemsInBottomSheet() = viewModelScope.launch {
         genreNameRepository.getGenreNames(cursor = null, size = INIT_GENRE_LIST_SIZE)
             .onSuccess { genres ->

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
@@ -272,14 +272,15 @@ class StoreViewModel @Inject constructor(
     fun toggleStoreBlockState(currentState: Boolean) = viewModelScope.launch {
         runCatching {
             when (currentState) {
-                true -> storeRepository.blockStore(storeId).getOrThrow()
-                false -> storeRepository.unblockStore(storeId).getOrThrow()
+                true -> storeRepository.unblockStore(storeId).getOrThrow()
+                false -> storeRepository.blockStore(storeId).getOrThrow()
             }
         }.onSuccess {
             updateStoreBlockDialogVisibility(false)
             updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
             updateStoreDetail()
-            StoreSideEffect.ShowBlockToast(!currentState) //이전 상태를 반전시켜서 UI에 전달합니다.
+            //이전 상태를 반전시켜서 UI에 전달합니다.
+            _sideEffect.send(StoreSideEffect.ShowBlockToast(!currentState))
         }.onFailure(Timber::e)
     }
 

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
@@ -269,6 +269,20 @@ class StoreViewModel @Inject constructor(
         }
     }
 
+    fun toggleStoreBlockState(currentState: Boolean) = viewModelScope.launch {
+        runCatching {
+            when (currentState) {
+                true -> storeRepository.blockStore(storeId).getOrThrow()
+                false -> storeRepository.unblockStore(storeId).getOrThrow()
+            }
+        }.onSuccess {
+            updateStoreBlockDialogVisibility(false)
+            updateBottomSheetVisibility(BottomSheetType.STORE_REPORT)
+            updateStoreDetail()
+            StoreSideEffect.ShowBlockToast(!currentState) //이전 상태를 반전시켜서 UI에 전달합니다.
+        }.onFailure(Timber::e)
+    }
+
     companion object {
         private const val DEBOUNCE_DELAY = 500L
         private const val INIT_GENRE_LIST_SIZE = 39

--- a/feature/store/src/main/java/com/napzak/market/store/store/component/StoreBottomSheetScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/component/StoreBottomSheetScreen.kt
@@ -4,12 +4,21 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.napzak.market.common.type.BottomSheetType
 import com.napzak.market.common.type.SortType
 import com.napzak.market.designsystem.component.bottomsheet.GenreSearchBottomSheet
 import com.napzak.market.designsystem.component.bottomsheet.SortBottomSheet
+import com.napzak.market.designsystem.component.dialog.NapzakDialog
+import com.napzak.market.designsystem.component.dialog.NapzakDialogDefault
+import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.store.R.string.store_block_dialog_cancel
+import com.napzak.market.feature.store.R.string.store_block_dialog_confirm
+import com.napzak.market.feature.store.R.string.store_block_dialog_content
+import com.napzak.market.feature.store.R.string.store_block_dialog_title
 import com.napzak.market.genre.model.Genre
 import com.napzak.market.store.store.state.StoreBottomSheetState
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,6 +33,9 @@ internal fun StoreBottomSheetScreen(
     onTextChange: (String) -> Unit,
     onGenreSelectButtonClick: (List<Genre>) -> Unit,
     onStoreReportButtonClick: () -> Unit,
+    onStoreBlockButtonClick: () -> Unit,
+    onStoreBlockConfirm: () -> Unit,
+    onStoreBlockDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     with(storeBottomSheetState) {
@@ -52,7 +64,22 @@ internal fun StoreBottomSheetScreen(
                 sheetState = sheetState,
                 onDismissRequest = { onDismissRequest(BottomSheetType.STORE_REPORT) },
                 onReportButtonClick = onStoreReportButtonClick,
+                onBlockButtonClick = onStoreBlockButtonClick,
                 modifier = modifier,
+            )
+        }
+
+        if (isStoreBlockDialogVisible) {
+            NapzakDialog(
+                title = stringResource(store_block_dialog_title),
+                subTitle = stringResource(store_block_dialog_content),
+                confirmText = stringResource(store_block_dialog_confirm),
+                dismissText = stringResource(store_block_dialog_cancel),
+                onConfirmClick = onStoreBlockConfirm,
+                onDismissClick = onStoreBlockDismiss,
+                dialogColor = NapzakDialogDefault.color.copy(
+                    titleColor = NapzakMarketTheme.colors.black,
+                ),
             )
         }
     }

--- a/feature/store/src/main/java/com/napzak/market/store/store/component/StoreBottomSheetScreen.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/component/StoreBottomSheetScreen.kt
@@ -28,6 +28,7 @@ internal fun StoreBottomSheetScreen(
     selectedGenres: List<Genre>,
     genreItems: List<Genre>,
     sortType: SortType,
+    isStoreBlocked: Boolean,
     onDismissRequest: (BottomSheetType) -> Unit,
     onSortItemClick: (SortType) -> Unit,
     onTextChange: (String) -> Unit,
@@ -62,6 +63,7 @@ internal fun StoreBottomSheetScreen(
         if (isStoreReportBottomSheetVisible) {
             StoreReportBottomSheet(
                 sheetState = sheetState,
+                isStoreBlocked = isStoreBlocked,
                 onDismissRequest = { onDismissRequest(BottomSheetType.STORE_REPORT) },
                 onReportButtonClick = onStoreReportButtonClick,
                 onBlockButtonClick = onStoreBlockButtonClick,

--- a/feature/store/src/main/java/com/napzak/market/store/store/component/StoreReportBottomSheet.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/component/StoreReportBottomSheet.kt
@@ -22,12 +22,14 @@ import com.napzak.market.designsystem.component.bottomsheet.DragHandleBottomShee
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.store.R.string.store_block
 import com.napzak.market.feature.store.R.string.store_report
+import com.napzak.market.feature.store.R.string.store_unblock
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun StoreReportBottomSheet(
     sheetState: SheetState,
+    isStoreBlocked: Boolean,
     onDismissRequest: () -> Unit,
     onReportButtonClick: () -> Unit,
     onBlockButtonClick: () -> Unit,
@@ -58,7 +60,7 @@ internal fun StoreReportBottomSheet(
         Spacer(Modifier.height(20.dp))
         BottomSheetMenuItem(
             menuIcon = ImageVector.vectorResource(ic_circle_block),
-            menuName = stringResource(store_block),
+            menuName = stringResource(if (isStoreBlocked) store_unblock else store_block),
             onItemClick = onBlockButtonClick,
             textColor = NapzakMarketTheme.colors.gray400,
         )
@@ -75,6 +77,7 @@ private fun StoreBottomSheetPreview(modifier: Modifier = Modifier) {
     NapzakMarketTheme {
         StoreReportBottomSheet(
             sheetState = sheetState,
+            isStoreBlocked = false,
             onDismissRequest = {},
             onReportButtonClick = {},
             onBlockButtonClick = {},

--- a/feature/store/src/main/java/com/napzak/market/store/store/component/StoreReportBottomSheet.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/component/StoreReportBottomSheet.kt
@@ -1,5 +1,7 @@
 package com.napzak.market.store.store.component
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
@@ -14,9 +16,11 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.R
+import com.napzak.market.designsystem.R.drawable.ic_circle_block
 import com.napzak.market.designsystem.component.bottomsheet.BottomSheetMenuItem
 import com.napzak.market.designsystem.component.bottomsheet.DragHandleBottomSheet
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.store.R.string.store_block
 import com.napzak.market.feature.store.R.string.store_report
 import kotlinx.coroutines.launch
 
@@ -26,6 +30,7 @@ internal fun StoreReportBottomSheet(
     sheetState: SheetState,
     onDismissRequest: () -> Unit,
     onReportButtonClick: () -> Unit,
+    onBlockButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -50,6 +55,13 @@ internal fun StoreReportBottomSheet(
             },
             textColor = NapzakMarketTheme.colors.red,
         )
+        Spacer(Modifier.height(20.dp))
+        BottomSheetMenuItem(
+            menuIcon = ImageVector.vectorResource(ic_circle_block),
+            menuName = stringResource(store_block),
+            onItemClick = onBlockButtonClick,
+            textColor = NapzakMarketTheme.colors.gray400,
+        )
     }
 }
 
@@ -65,6 +77,7 @@ private fun StoreBottomSheetPreview(modifier: Modifier = Modifier) {
             sheetState = sheetState,
             onDismissRequest = {},
             onReportButtonClick = {},
+            onBlockButtonClick = {},
             modifier = modifier
         )
     }

--- a/feature/store/src/main/java/com/napzak/market/store/store/state/StoreBottomSheetState.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/state/StoreBottomSheetState.kt
@@ -4,4 +4,5 @@ data class StoreBottomSheetState(
     val isSortBottomSheetVisible: Boolean = false,
     val isGenreSearchingBottomSheetVisible: Boolean = false,
     val isStoreReportBottomSheetVisible: Boolean = false,
+    val isStoreBlockDialogVisible: Boolean = false,
 )

--- a/feature/store/src/main/res/values/strings.xml
+++ b/feature/store/src/main/res/values/strings.xml
@@ -15,10 +15,13 @@
 
     <string name="store_report">마켓 신고하기</string>
     <string name="store_block">마켓 차단하기</string>
+    <string name="store_unblock">마켓 차단 해제하기</string>
     <string name="store_block_dialog_title">마켓을 차단하시겠어요?</string>
     <string name="store_block_dialog_content">차단하면 해당 마켓과 대화할 수 없어요.</string>
     <string name="store_block_dialog_confirm">예</string>
     <string name="store_block_dialog_cancel">아니오</string>
+    <string name="store_toast_block">마켓을 차단했어요.</string>
+    <string name="store_toast_unblock">마켓 차단을 해제했어요.</string>
 
     <string name="store_edit_title_name">마켓 이름</string>
     <string name="store_edit_sub_title_name">띄어쓰기 없이 한글, 영문, 숫자만 사용할 수 있어요 (최대 20자)</string>

--- a/feature/store/src/main/res/values/strings.xml
+++ b/feature/store/src/main/res/values/strings.xml
@@ -14,6 +14,11 @@
     <string name="store_edit_profile">프로필 편집</string>
 
     <string name="store_report">마켓 신고하기</string>
+    <string name="store_block">마켓 차단하기</string>
+    <string name="store_block_dialog_title">마켓을 차단하시겠어요?</string>
+    <string name="store_block_dialog_content">차단하면 해당 마켓과 대화할 수 없어요.</string>
+    <string name="store_block_dialog_confirm">예</string>
+    <string name="store_block_dialog_cancel">아니오</string>
 
     <string name="store_edit_title_name">마켓 이름</string>
     <string name="store_edit_sub_title_name">띄어쓰기 없이 한글, 영문, 숫자만 사용할 수 있어요 (최대 20자)</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #362 

## Work Description ✏️
- 차단/차단 해제 api 연결
- 마켓 상세, 채팅방 정보 api 응답 필드 추가
- 마켓, 채팅방 화면에 api 연결 및 수정된 도메인 모델 반영
- 바텀시트 차단 버튼, 팝업, 토스트 메세지 추가

## Screenshot 📸
| 채팅방 화면 | 마켓 화면 |
|:--:|:--:|
|  <video src="https://github.com/user-attachments/assets/9b9472a2-c0ee-4b75-b4fb-a7e76216f2d4" width="360"></video> | <video src="https://github.com/user-attachments/assets/9d3aeef5-e038-4904-bf73-d92aae5c16b5" width="360"></video> |

## To Reviewers 📢
- 어쩔 수 없이 다른 사람 뷰를 건들였는데, 혹시라도 본인 담당 화면에 들어간 코드가 맘에 안들면 맘껏 지적해주세요~