### PR TITLE
[CHORE/#377] 신고화면 및 접근 제한 팝업 라이팅 수정

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/popup/NapzakPopup.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/popup/NapzakPopup.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,7 +33,7 @@ import com.napzak.market.designsystem.theme.NapzakMarketTheme
 @Composable
 fun NapzakPopup(
     title: String,
-    subTitle: String,
+    subTitle: AnnotatedString,
     icon: ImageVector,
     buttonColor: Color,
     buttonText: String,
@@ -142,7 +142,7 @@ private fun NapzakPopupPreview(modifier: Modifier = Modifier) {
     NapzakMarketTheme {
         NapzakPopup(
             title = "업데이트가 필요해요!",
-            subTitle = "원활한 서비스 이용을 위해\n" + "최신 버전으로 업데이트해주세요.",
+            subTitle = AnnotatedString("원활한 서비스 이용을 위해\n" + "최신 버전으로 업데이트해주세요."),
             icon = ImageVector.vectorResource(ic_purple_change),
             buttonColor = NapzakMarketTheme.colors.purple500,
             buttonText = "납작마켓 업데이트",

--- a/core/ui_util/src/main/java/com/napzak/market/ui_util/StringExt.kt
+++ b/core/ui_util/src/main/java/com/napzak/market/ui_util/StringExt.kt
@@ -1,5 +1,9 @@
 package com.napzak.market.ui_util
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import java.text.DecimalFormat
 
 fun String.formatToPriceString(): String = toLongOrNull()?.let {
@@ -11,5 +15,23 @@ fun String.ellipsis(maxLength: Int): String {
         this.take(maxLength) + "…"
     } else {
         this
+    }
+}
+
+fun String.underline(target: String): AnnotatedString {
+    val fullText = this
+    val startIndex = fullText.indexOf(target)
+
+    if (startIndex == -1) return AnnotatedString(this)
+
+    val endIndex = startIndex + target.length
+
+    return buildAnnotatedString {
+        append(fullText)
+        addStyle(
+            style = SpanStyle(textDecoration = TextDecoration.Underline),
+            start = startIndex,
+            end = endIndex
+        )
     }
 }

--- a/feature/login/src/main/java/com/napzak/market/login/component/UserReportedPopup.kt
+++ b/feature/login/src/main/java/com/napzak/market/login/component/UserReportedPopup.kt
@@ -9,9 +9,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.napzak.market.designsystem.R.drawable.ic_square_red_warning
 import com.napzak.market.designsystem.component.popup.NapzakPopup
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
+import com.napzak.market.feature.login.R.string.napzak_email
+import com.napzak.market.feature.login.R.string.reported_popup_confirm_button
 import com.napzak.market.feature.login.R.string.reported_popup_subtitle
 import com.napzak.market.feature.login.R.string.reported_popup_title
-import com.napzak.market.feature.login.R.string.reported_popup_confirm_button
+import com.napzak.market.ui_util.underline
 
 @Composable
 fun UserReportedPopup(
@@ -20,7 +22,7 @@ fun UserReportedPopup(
 ) {
     NapzakPopup(
         title = stringResource(reported_popup_title),
-        subTitle = stringResource(reported_popup_subtitle),
+        subTitle = stringResource(reported_popup_subtitle).underline(stringResource(napzak_email)),
         icon = ImageVector.vectorResource(ic_square_red_warning),
         buttonColor = NapzakMarketTheme.colors.red,
         buttonText = stringResource(reported_popup_confirm_button),

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -1,8 +1,13 @@
 <resources>
     <string name="app_name">NapzakMarket</string>
     <string name="login_kakao">카카오 로그인하기</string>
+    <string name="napzak_email">napzakmarket@gmail.com</string>
 
     <string name="reported_popup_title">접근이 불가합니다.</string>
-    <string name="reported_popup_subtitle">해당 계정은 정책 위반으로 인해\n앱 서비스 접근이 불가합니다.</string>
+    <string name="reported_popup_subtitle">
+        서비스 운영 정책에 따라\n
+        현재 계정은 이용이 제한된 상태입니다.\n
+        관련 문의: napzakmarket@gmail.com
+    </string>
     <string name="reported_popup_confirm_button">확인</string>
 </resources>

--- a/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
@@ -75,11 +75,8 @@ internal fun ReportRoute(
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
             .collect { sideEffect ->
                 when (sideEffect) {
-                    ReportSideEffect.NavigateUp -> {
-                        navigateUp()
-                    }
-
                     is ReportSideEffect.ReportCompleted -> {
+                        navigateUp()
                         napzakToast.makeText(
                             toastType = ToastType.COMMON,
                             message = context.getString(report_toast_success),

--- a/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportScreen.kt
@@ -47,6 +47,7 @@ import com.napzak.market.designsystem.component.toast.ToastType
 import com.napzak.market.designsystem.component.topbar.NavigateUpTopBar
 import com.napzak.market.designsystem.theme.NapzakMarketTheme
 import com.napzak.market.feature.report.R.string.report_button_submit
+import com.napzak.market.feature.report.R.string.report_toast_success
 import com.napzak.market.report.component.ReportContactSection
 import com.napzak.market.report.component.ReportDetailSection
 import com.napzak.market.report.component.ReportReasonSection
@@ -78,10 +79,10 @@ internal fun ReportRoute(
                         navigateUp()
                     }
 
-                    is ReportSideEffect.ShowToast -> {
+                    is ReportSideEffect.ReportCompleted -> {
                         napzakToast.makeText(
                             toastType = ToastType.COMMON,
-                            message = sideEffect.message,
+                            message = context.getString(report_toast_success),
                             fontType = ToastFontType.SMALL,
                             yOffset = 50,
                         )

--- a/feature/report/src/main/java/com/napzak/market/report/ReportSideEffect.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportSideEffect.kt
@@ -1,6 +1,6 @@
 package com.napzak.market.report
 
 sealed interface ReportSideEffect {
-    data class ShowToast(val message: String) : ReportSideEffect
     data object NavigateUp : ReportSideEffect
+    data object ReportCompleted : ReportSideEffect
 }

--- a/feature/report/src/main/java/com/napzak/market/report/ReportSideEffect.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportSideEffect.kt
@@ -1,6 +1,5 @@
 package com.napzak.market.report
 
 sealed interface ReportSideEffect {
-    data object NavigateUp : ReportSideEffect
     data object ReportCompleted : ReportSideEffect
 }

--- a/feature/report/src/main/java/com/napzak/market/report/ReportViewModel.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportViewModel.kt
@@ -35,32 +35,42 @@ internal class ReportViewModel @Inject constructor(
         detail: String,
         contact: String,
     ) = viewModelScope.launch {
+        if (id == null) return@launch
+
+        isUploading = true
+        val reportParameters = ReportParameters(
+            title = reason,
+            description = detail,
+            contact = contact,
+        )
+
         runCatching {
-            isUploading = true
-            val reportParameters = ReportParameters(
-                title = reason,
-                description = detail,
-                contact = contact,
+            sendReport(reportType, id, reportParameters)
+        }.onSuccess {
+            _sideEffect.send(ReportSideEffect.ReportCompleted)
+        }.onFailure { t ->
+            Timber.e(t)
+        }.also {
+            isUploading = false
+        }
+    }
+
+    private suspend fun sendReport(
+        reportType: ReportType,
+        id: Long,
+        reportParameters: ReportParameters,
+    ) {
+        when (reportType) {
+            ReportType.PRODUCT -> sendProductReport(
+                productId = id,
+                reportParameters = reportParameters,
             )
 
-            when (reportType) {
-                ReportType.PRODUCT -> sendProductReport(
-                    productId = id!!,
-                    reportParameters = reportParameters,
-                )
-
-                ReportType.USER -> sendUserReport(
-                    userId = id!!,
-                    reportParameters = reportParameters,
-                )
-            }
-        }.onSuccess {
-            _sideEffect.send(ReportSideEffect.NavigateUp)
-            _sideEffect.send(ReportSideEffect.ReportCompleted)
-        }.onFailure(Timber::e)
-            .also {
-                isUploading = false
-            }
+            ReportType.USER -> sendUserReport(
+                userId = id,
+                reportParameters = reportParameters,
+            )
+        }
     }
 
     private suspend fun sendProductReport(

--- a/feature/report/src/main/java/com/napzak/market/report/ReportViewModel.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/ReportViewModel.kt
@@ -56,7 +56,7 @@ internal class ReportViewModel @Inject constructor(
             }
         }.onSuccess {
             _sideEffect.send(ReportSideEffect.NavigateUp)
-            _sideEffect.send(ReportSideEffect.ShowToast(REPORT_SNACK_BAR_MESSAGE))
+            _sideEffect.send(ReportSideEffect.ReportCompleted)
         }.onFailure(Timber::e)
             .also {
                 isUploading = false
@@ -85,10 +85,5 @@ internal class ReportViewModel @Inject constructor(
 
     companion object {
         private const val ID = "id"
-        private const val REPORT_SNACK_BAR_MESSAGE =
-            "소중한 신고 감사합니다! \uD83D\uDE4F\n\n" +
-                    "신고 내용을 꼼꼼히 검토하여\n" +
-                    "입력하신 연락처로 결과를 안내해드릴게요.\n" +
-                    "추가 정보가 필요할 경우 동일한 연락처로 문의드릴 수 있어요."
     }
 }

--- a/feature/report/src/main/java/com/napzak/market/report/component/ReportContactSection.kt
+++ b/feature/report/src/main/java/com/napzak/market/report/component/ReportContactSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.napzak.market.designsystem.component.textfield.NapzakDefaultTextField
@@ -70,6 +72,7 @@ internal fun ReportContactSection(
             hintTextStyle = NapzakMarketTheme.typography.caption12m,
             hintTextColor = NapzakMarketTheme.colors.gray200,
             isSingleLined = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
             modifier = Modifier
                 .onFocusEvent {
                     bringIntoViewRequester.bringIntoView(coroutineScope, it)

--- a/feature/report/src/main/res/values/strings.xml
+++ b/feature/report/src/main/res/values/strings.xml
@@ -27,4 +27,11 @@
     <string name="report_user_slang_used">욕설/비속어 등 불쾌한 표현을 사용했어요</string>
     <string name="report_user_miscellaneous">기타 문제가 있어요</string>
     <string name="report_button_submit">제출하기</string>
+
+    <string name="report_toast_success">
+        소중한 신고 감사합니다! \uD83D\uDE4F\n\n
+        신고 내용을 꼼꼼히 검토하여\n
+        입력하신 이메일로 결과를 안내해드릴게요.\n
+        추가 정보가 필요할 경우 동일한 이메일로 문의드릴 수 있어요.
+    </string>
 </resources>

--- a/feature/report/src/main/res/values/strings.xml
+++ b/feature/report/src/main/res/values/strings.xml
@@ -9,8 +9,8 @@
         \n안전한 거래 공간을 함께 만들어가요!
     </string>
     <string name="report_input_letter_num_detail">%d/%d</string>
-    <string name="report_input_title_contact">연락처 입력</string>
-    <string name="report_input_place_holder_contact">신고 검토 결과를 받아볼 이메일 또는 전화번호를 알려주세요</string>
+    <string name="report_input_title_contact">이메일 주소 입력</string>
+    <string name="report_input_place_holder_contact">신고 관련 안내 및 확인을 위해 이메일을 입력해주세요.</string>
 
     <string name="report_product_title">상품을 신고하는 이유를 알려주세요</string>
     <string name="report_product_banned_product">거래 금지 상품을 판매하고 있어요</string>

--- a/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -63,7 +64,8 @@ internal fun SplashRoute(
 
     LaunchedEffect(Unit) {
         val appVersion = context.getVersionName()
-        if (appVersion != null) viewModel.checkAppVersion(appVersion) else { /* null인 경우 대기 */}
+        if (appVersion != null) viewModel.checkAppVersion(appVersion) else { /* null인 경우 대기 */
+        }
         delay(2500)
     }
 
@@ -123,7 +125,7 @@ private fun UpdatePopup(
     ) {
         NapzakPopup(
             title = stringResource(update_popup_title),
-            subTitle = stringResource(update_popup_subtitle),
+            subTitle = AnnotatedString(stringResource(update_popup_subtitle)),
             icon = ImageVector.vectorResource(ic_purple_change),
             buttonColor = NapzakMarketTheme.colors.purple500,
             buttonText = stringResource(update_popup_button),

--- a/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
+++ b/feature/splash/src/main/java/com/napzak/market/splash/SplashScreen.kt
@@ -64,8 +64,7 @@ internal fun SplashRoute(
 
     LaunchedEffect(Unit) {
         val appVersion = context.getVersionName()
-        if (appVersion != null) viewModel.checkAppVersion(appVersion) else { /* null인 경우 대기 */
-        }
+        if (appVersion != null) viewModel.checkAppVersion(appVersion) else { /* null인 경우 대기 */ }
         delay(2500)
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #377 

## Work Description ✏️
- 연락처 입력란의 힌트 텍스트 수정
- 연락처 입력란의 `KeyboardOption`을 이메일로 설정
- `ReportViewModel`의 메서드 책임 분리 강화
- `NapzakPopup`의 파라미터 타입 수정
- 접근 제한 팝업의 텍스트 수정

## Screenshot 📸

<img width="360" src="https://github.com/user-attachments/assets/c1810bdd-baa8-47da-b37d-e2d9e9f80f4c" />

<img width="360" src="https://github.com/user-attachments/assets/d2093689-13ad-4d29-ac32-18ccba8888cf" />


## To Reviewers 📢

- 슬랙에서 논의된 변경사항을 반영했습니다!