### PR TITLE
[Refactor/#379] 믹스패널 로깅 로직 추상화 및 도메인별 트래커 구현

### DIFF
--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ExploreTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ExploreTracker.kt
@@ -1,0 +1,115 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Explore
+ * Description : 둘러보기(탐색) 화면 관련 트래킹
+ */
+class ExploreTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Viewed Explore
+     * Description : 둘러보기 화면 조회
+     * @param isForSale 판매탭 여부 (true: 판매글, false: 구함글)
+     */
+    fun trackViewedExplore(isForSale: Boolean) {
+        analytics.logEvent(
+            MixpanelConstants.VIEWED_EXPLORE,
+            mapOf(
+                TAB to if (isForSale) TAB_FOR_SALE else TAB_WANTED,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Applied Genre Filter
+     * Description : 장르 필터 적용
+     * @param filterCount 적용된 필터 개수
+     * @param isForSale 현재 선택된 탭 정보
+     */
+    fun trackAppliedGenreFilter(filterCount: Int, isForSale: Boolean) {
+        analytics.logEvent(
+            MixpanelConstants.APPLIED_GENRE_FILTER,
+            mapOf(
+                FILTER_COUNT to filterCount,
+                TAB to if (isForSale) TAB_FOR_SALE else TAB_WANTED,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Applied array Filter
+     * Description : 정렬 필터 적용
+     * @param sort 정렬 방식 (latest, popular 등)
+     * @param isForSale 현재 선택된 탭 정보
+     */
+    fun trackAppliedArrayFilter(sort: String, isForSale: Boolean) {
+        analytics.logEvent(
+            MixpanelConstants.APPLIED_ARRAY_FILTER,
+            mapOf(
+                SORT to sort,
+                TAB to if (isForSale) TAB_FOR_SALE else TAB_WANTED,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Viewed Product
+     * Description : 탐색 화면에서 상품 상세 진입
+     * @param postId 게시글 ID
+     * @param postType 게시글 타입 (for_sale, wanted)
+     */
+    fun trackViewedProduct(postId: Long, postType: String) {
+        analytics.logEvent(
+            MixpanelConstants.VIEWED_PRODUCT,
+            mapOf(
+                POST_ID to postId,
+                POST_TYPE to postType,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Started Chat
+     * Description : 탐색 화면에서 채팅 시작
+     * @param postId 게시글 ID
+     * @param postType 게시글 타입
+     * @param userRole 유저 역할 (buyer, seller)
+     */
+    fun trackStartedChatFromExplore(postId: Long, postType: String, userRole: String) {
+        analytics.logEvent(
+            MixpanelConstants.STARTED_CHAT,
+            mapOf(
+                POST_ID to postId,
+                POST_TYPE to postType,
+                USER_ROLE to userRole,
+            ),
+        )
+    }
+
+    companion object {
+        private const val TAB = "tab"
+        private const val FILTER_COUNT = "filter_count"
+        private const val SORT = "sort"
+        private const val POST_ID = "post_id"
+        private const val POST_TYPE = "post_type"
+        private const val USER_ROLE = "user_role"
+
+        private const val TAB_FOR_SALE = "for_sale"
+        private const val TAB_WANTED = "wanted"
+
+        const val SORT_LATEST = "latest"
+        const val SORT_POPULAR = "popular"
+        const val SORT_HIGH_PRICE = "high_price"
+        const val SORT_LOW_PRICE = "low_price"
+
+        const val POST_TYPE_FOR_SALE = "for_sale"
+        const val POST_TYPE_WANTED = "wanted"
+
+        const val USER_ROLE_BUYER = "buyer"
+        const val USER_ROLE_SELLER = "seller"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
@@ -1,0 +1,86 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Home
+ * Description : 홈 화면 관련 트래킹
+ */
+class HomeTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Clicked Banner
+     * Description : 홈 상단/미니 배너 클릭
+     * @param bannerId 배너 ID
+     * @param bannerType 배너 타입 (main, mini 등)
+     * @param bannerIndex 배너 위치 순서
+     */
+    fun trackClickedBanner(bannerId: Long, bannerType: String, bannerIndex: Int) {
+        analytics.logEvent(
+            MixpanelConstants.CLICKED_BANNER,
+            mapOf(
+                BANNER_ID to bannerId,
+                BANNER_TYPE to bannerType,
+                BANNER_INDEX to bannerIndex,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Clicked custom genre
+     * Description : 홈 화면 추천 상품 섹션 클릭 (기존 상수명 유지)
+     * @param itemIndex 아이템 위치 순서
+     */
+    fun trackClickedRecommendProduct(itemIndex: Int) {
+        analytics.logEvent(
+            MixpanelConstants.CLICKED_CUSTOM_GENRE,
+            mapOf(
+                ITEM_INDEX to itemIndex,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Viewed Popular For Sale
+     * Description : 인기 판매중 아이템 섹션 조회
+     */
+    fun trackViewedPopularSale() {
+        analytics.logEvent(
+            MixpanelConstants.VIEWED_POPULAR_SALE,
+            mapOf(
+                SORT to POPULAR,
+                FROM to HOME,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Viewed Popular Wanted
+     * Description : 인기 구함중 아이템 섹션 조회
+     */
+    fun trackViewedPopularWanted() {
+        analytics.logEvent(
+            MixpanelConstants.VIEWED_POPULAR_WANTED,
+            mapOf(
+                SORT to POPULAR,
+                FROM to HOME,
+            ),
+        )
+    }
+
+    companion object {
+        private const val BANNER_ID = "banner_id"
+        private const val BANNER_TYPE = "banner_type"
+        private const val BANNER_INDEX = "banner_index"
+        private const val ITEM_INDEX = "item_index"
+        private const val SORT = "sort"
+        private const val FROM = "from"
+        private const val HOME = "home"
+        private const val POPULAR = "popular"
+
+        const val BANNER_MAIN = "main"
+        const val BANNER_MINI = "mini"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MyPageTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MyPageTracker.kt
@@ -1,0 +1,20 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : MyPage
+ * Description : 마이페이지 관련 트래킹
+ */
+class MyPageTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Viewed MyPage
+     * Description : 마이페이지 진입
+     */
+    fun trackViewedMyPage() {
+        analytics.logEvent(MixpanelConstants.VIEWED_MYPAGE)
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/NapzakAnalytics.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/NapzakAnalytics.kt
@@ -1,0 +1,20 @@
+package com.napzak.market.mixpanel
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NapzakAnalytics @Inject constructor(
+    private val mixpanelApi: MixpanelAPI,
+) {
+    fun logEvent(name: String, params: Map<String, Any?> = emptyMap()) {
+        mixpanelApi.track(
+            name,
+            JSONObject().apply {
+                params.forEach { (key, value) -> put(key, value) }
+            },
+        )
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/OnboardingTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/OnboardingTracker.kt
@@ -1,0 +1,64 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Onboarding
+ * Description : 온보딩 및 회원가입 관련 트래킹
+ */
+class OnboardingTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Signed Up
+     * Description : 로그인 완료
+     * @param method 가입 수단
+     */
+    fun trackSignedUp(method: String) {
+        analytics.logEvent(MixpanelConstants.SIGNED_UP)
+    }
+
+    /**
+     * Event       : Skipped Genres
+     * Description : 관심 장르 선택 건너뛰기 클릭
+     */
+    fun trackSkippedGenres() {
+        analytics.logEvent(MixpanelConstants.SKIPPED_GENRES)
+    }
+
+    /**
+     * Event       : Completed Onboarding
+     * Description : 온보딩 완료
+     * @param method 가입 수단
+     * @param genresCount 선택된 장르 개수
+     * @param genresCategory 선택된 장르 리스트
+     * @param isSkipped 장르 선택 건너뛰기 여부
+     */
+    fun trackCompletedOnboarding(
+        method: String,
+        genresCount: Int,
+        genresCategory: List<String>,
+    ) {
+        analytics.logEvent(
+            MixpanelConstants.COMPLETED_ONBOARDING,
+            mapOf(
+                METHOD to method,
+                PLATFORM to PLATFORM_ANDROID,
+                GENRES_COUNT to genresCount,
+                GENRES_CATEGORY to genresCategory,
+            ),
+        )
+    }
+
+    companion object {
+        private const val METHOD = "method"
+        private const val PLATFORM = "platform"
+        private const val GENRES_COUNT = "genres_selected_count"
+        private const val GENRES_CATEGORY = "genres_category"
+
+        private const val PLATFORM_ANDROID = "android"
+
+        const val METHOD_KAKAO = "kakao"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/PostingTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/PostingTracker.kt
@@ -1,0 +1,44 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Posting
+ * Description : 게시글 작성 관련 트래킹
+ */
+class PostingTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Created Post
+     * Description : 게시글 작성 완료
+     * @param postId 게시글 ID
+     * @param postType 게시글 타입
+     * @param genreName 장르명
+     * @param userRole 유저 역할
+     */
+    fun trackCreatedPost(postId: Long, postType: String, genreName: String?, userRole: String) {
+        analytics.logEvent(
+            MixpanelConstants.CREATED_POST,
+            mapOf(
+                POST_ID to postId,
+                POST_TYPE to postType,
+                GENRES_CATEGORY to genreName,
+                USER_ROLE to userRole,
+            ),
+        )
+    }
+
+    companion object {
+        private const val POST_ID = "post_id"
+        private const val POST_TYPE = "post_type"
+        private const val GENRES_CATEGORY = "genres_category"
+        private const val USER_ROLE = "user_role"
+
+        const val POST_TYPE_FOR_SALE = "for_sale"
+        const val POST_TYPE_WANTED = "wanted"
+        const val USER_ROLE_SELLER = "seller"
+        const val USER_ROLE_BUYER = "buyer"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ReportTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ReportTracker.kt
@@ -1,0 +1,28 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Report / Detail Action
+ * Description : 신고 및 상품 상세 화면 주요 액션(상태 변경 등) 관련 트래킹
+ */
+class ReportTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Opened Report Overlay_product
+     * Description : 상품 신고 바텀시트/오버레이 노출
+     */
+    fun trackOpenedReportProduct() {
+        analytics.logEvent(MixpanelConstants.OPENED_REPORT_PRODUCT)
+    }
+
+    /**
+     * Event       : Opened Report Overlay_market
+     * Description : 마켓(채팅/상점) 신고 바텀시트/오버레이 노출
+     */
+    fun trackOpenedReportMarket() {
+        analytics.logEvent(MixpanelConstants.OPENED_REPORT_MARKET)
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SearchTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SearchTracker.kt
@@ -1,0 +1,70 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Search
+ * Description : 검색 기능 관련 트래킹
+ */
+class SearchTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Opened Search
+     * Description : 검색 화면 진입
+     */
+    fun trackOpenedSearch() {
+        analytics.logEvent(MixpanelConstants.OPENED_SEARCH)
+    }
+
+    /**
+     * Event       : Executed Search
+     * Description : 검색 실행
+     * @param searchSource 검색 소스
+     * @param keyword 검색어
+     */
+    fun trackExecutedSearch(
+        searchSource: String,
+        keyword: String? = null,
+    ) {
+        analytics.logEvent(
+            MixpanelConstants.EXECUTED_SEARCH,
+            mapOf(
+                SEARCH_SOURCE to searchSource,
+                SEARCH_TEXT to keyword,
+            ),
+        )
+    }
+
+    /**
+     * Event       : Clicked Suggestion
+     * Description : 추천 검색어 클릭
+     * @param suggestionType 추천 타입 (keyword, genre 등)
+     * @param suggestionIndex 추천 순서
+     */
+    fun trackClickedSuggestion(suggestionType: String, suggestionIndex: Int) {
+        analytics.logEvent(
+            MixpanelConstants.CLICKED_SUGGESTION,
+            mapOf(
+                SUGGESTION_TYPE to suggestionType,
+                SUGGESTION_INDEX to suggestionIndex,
+            ),
+        )
+    }
+
+    companion object {
+        private const val SEARCH_SOURCE = "search_source"
+        private const val SEARCH_TEXT = "keyword"
+        private const val SUGGESTION_TYPE = "suggestion_type"
+        private const val SUGGESTION_INDEX = "suggestion_index"
+
+        const val SOURCE_ICON = "icon"
+        const val SOURCE_ENTER = "enter"
+        const val SOURCE_SEARCH_BAR = "search_bar"
+        const val SOURCE_GENRE_PAGE = "genre_page"
+
+        const val SUGGESTION_TYPE_KEYWORD = "keyword"
+        const val SUGGESTION_TYPE_GENRE = "genre"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SettingsTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SettingsTracker.kt
@@ -1,0 +1,63 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Settings
+ * Description : 설정 관련 트래킹
+ */
+class SettingsTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Viewed Settings
+     * Description : 설정 화면 진입
+     */
+    fun trackViewedSetting() {
+        analytics.logEvent(MixpanelConstants.VIEWED_SETTING)
+    }
+
+    /**
+     * Event       : Toggled Alarm
+     * Description : 알림 설정 변경 (ON/OFF)
+     * @param status 알림 상태 (on, off)
+     */
+    fun trackToggledAlarm(status: String) {
+        analytics.logEvent(
+            MixpanelConstants.TOGGLED_ALARM,
+            mapOf(STATUS to status),
+        )
+    }
+
+    /**
+     * Event       : Logged Out
+     * Description : 로그아웃 실행
+     */
+    fun trackLoggedOut() {
+        analytics.logEvent(MixpanelConstants.LOGGED_OUT)
+    }
+
+    /**
+     * Event       : Started Withdrawal
+     * Description : 서비스 탈퇴 시작
+     */
+    fun trackStartedWithdrawal() {
+        analytics.logEvent(MixpanelConstants.STARTED_WITHDRAWAL)
+    }
+
+    /**
+     * Event       : Completed Withdrawal
+     * Description : 서비스 탈퇴 완료
+     */
+    fun trackCompletedWithdrawal() {
+        analytics.logEvent(MixpanelConstants.COMPLETED_WITHDRAWAL)
+    }
+
+    companion object {
+        private const val STATUS = "status"
+
+        const val STATE_ON = "on"
+        const val STATE_OFF = "off"
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #379

## Work Description ✏️
- 믹스패널 로깅 추상화: MixpanelAPI의 로직을 중앙화하여 관리하는 NapzakAnalytics 클래스를 구현했어요.
- 도메인별 트래커 클래스 구현: 로깅 로직을 도메인별로 분리하고 추상화해서 가독성을 높였어요.
- 이벤트 명세 가독성 확보: 각 트래커 메소드에 KDoc 주석을 추가해서 이벤트 명칭, 의도, 파라미터 설명을 명확하게 명시했어요.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [x] ViewModel 및 UI 레이어의 기존 로깅 코드를 신규 트래커 구조로 마이그레이션 (차기 이슈 진행 예정)

## To Reviewers 📢