### PR TITLE
[REFACTOR] 프로젝트 의존성 업그레이드

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,6 @@ dependencies {
     implementation(libs.kakao.v2.user)
     implementation(libs.kakao.v2.common)
     implementation(libs.androidx.room.compiler)
-    implementation(libs.androidx.multidex)
     implementation(libs.lottie.compose)
 
     implementation(platform(libs.firebase.bom))

--- a/build-logic/src/main/java/com/napzak/market/buildlogic/convention/ComposePlugin.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/convention/ComposePlugin.kt
@@ -1,6 +1,5 @@
 package com.napzak.market.buildlogic.convention
 
-import com.napzak.market.buildlogic.dsl.androidExtension
 import com.napzak.market.buildlogic.primitive.ComposePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -10,12 +9,6 @@ class ComposePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply<ComposePlugin>()
-
-            androidExtension.apply {
-                buildFeatures {
-                    compose = true
-                }
-            }
         }
     }
 }

--- a/build-logic/src/main/java/com/napzak/market/buildlogic/dsl/AndroidGradleDsl.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/dsl/AndroidGradleDsl.kt
@@ -2,17 +2,9 @@ package com.napzak.market.buildlogic.dsl
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestedExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
-
-fun Project.android(
-    action: TestedExtension.() -> Unit,
-) {
-    extensions.configure(action)
-}
 
 fun Project.androidApplicationExtension(
     action: ApplicationExtension.() -> Unit,
@@ -20,18 +12,8 @@ fun Project.androidApplicationExtension(
     extensions.configure(action)
 }
 
-internal val Project.applicationExtension: CommonExtension<*, *, *, *, *, *>
-    get() = extensions.getByType<ApplicationExtension>()
+internal fun Project.androidExtension() = extensions.getByType(CommonExtension::class)
 
-internal val Project.libraryExtension: CommonExtension<*, *, *, *, *, *>
-    get() = extensions.getByType<LibraryExtension>()
-
-internal val Project.androidExtension: CommonExtension<*, *, *, *, *, *>
-    get() = runCatching { libraryExtension }
-        .recoverCatching { applicationExtension }
-        .onFailure { println("Could not find Library or Application extension from this project") }
-        .getOrThrow()
-
-fun LibraryExtension.setNameSpace(nameSpace: String) {
+fun CommonExtension.setNameSpace(nameSpace: String) {
     namespace = "com.napzak.market.${nameSpace}"
 }

--- a/build-logic/src/main/java/com/napzak/market/buildlogic/dsl/ProjectDsl.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/dsl/ProjectDsl.kt
@@ -3,13 +3,10 @@ package com.napzak.market.buildlogic.dsl
 import org.gradle.api.Project
 
 fun Project.configureAndroidLibrary() {
-    android {
-        setCompileSdkVersion(libs.version("compileSdk").toInt())
-
-        defaultConfig {
+    androidExtension().apply {
+        compileSdk = libs.version("compileSdk").toInt()
+        defaultConfig.apply {
             minSdk = libs.version("minSdk").toInt()
-            targetSdk = libs.version("targetSdk").toInt()
-
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }
     }

--- a/build-logic/src/main/java/com/napzak/market/buildlogic/primitive/CommonAndroidPlugin.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/primitive/CommonAndroidPlugin.kt
@@ -1,18 +1,17 @@
 package com.napzak.market.buildlogic.primitive
 
-import com.android.build.gradle.BaseExtension
+import com.napzak.market.buildlogic.dsl.androidExtension
 import com.napzak.market.buildlogic.dsl.implementation
 import com.napzak.market.buildlogic.dsl.library
 import com.napzak.market.buildlogic.dsl.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 
 class CommonAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
-        extensions.getByType<BaseExtension>().apply {
-            defaultConfig {
+        androidExtension().apply {
+            defaultConfig.apply {
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
 

--- a/build-logic/src/main/java/com/napzak/market/buildlogic/primitive/KotlinPlugin.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/primitive/KotlinPlugin.kt
@@ -1,6 +1,6 @@
 package com.napzak.market.buildlogic.primitive
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
 import com.napzak.market.buildlogic.dsl.implementation
 import com.napzak.market.buildlogic.dsl.library
 import com.napzak.market.buildlogic.dsl.libs
@@ -8,7 +8,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -17,24 +17,20 @@ class KotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(plugins) {
-                apply("org.jetbrains.kotlin.android")
                 apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("org.jetbrains.kotlin.plugin.parcelize")
             }
 
-            extensions.getByType<BaseExtension>().apply {
-                compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_17
-                    targetCompatibility = JavaVersion.VERSION_17
-                }
+            extensions.findByType<CommonExtension>()?.apply {
+                compileOptions.sourceCompatibility = JavaVersion.VERSION_17
+                compileOptions.targetCompatibility = JavaVersion.VERSION_17
             }
 
             tasks.withType<KotlinCompile> {
                 compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
             }
 
-            dependencies{
-
+            dependencies {
                 implementation(libs.library("kotlinx-immutable"))
                 implementation(libs.library("kotlinx-serialization-json"))
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.jvm) apply false

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -29,5 +29,4 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.coil.compose)
     implementation(libs.timber)
-    implementation(libs.androidx.multidex)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "8.11.1"
+agp = "9.0.0"
 minSdk = "28"
 targetSdk = "35"
-compileSdk = "35"
+compileSdk = "36"
 jvmTarget = "17"
 versionCode = "10004"
 versionName = "1.0.4"
@@ -10,31 +10,30 @@ versionName = "1.0.4"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-androidxLifecycleRuntimeKtx = "2.9.3"
-androidxCoreKtx = "1.16.0"
-androidxDatastore = "1.1.7"
-androidxAppCompat = "1.7.0"
-androidxRoomCompiler = "2.7.1"
-androidxMultidex = "2.0.1"
+androidxLifecycleRuntimeKtx = "2.10.0"
+androidxCoreKtx = "1.18.0"
+androidxDatastore = "1.2.1"
+androidxAppCompat = "1.7.1"
+androidxRoomCompiler = "2.8.4"
 
-kotlin = "2.1.21"
+kotlin = "2.3.10"
 kotlinxImmutable = "0.4.0"
-ksp = "2.1.21-2.0.2"
-kotlinSerialization = "1.9.0"
+ksp = "2.3.6"
+kotlinSerialization = "1.11.0"
 kotlinCoroutine = "1.10.2"
 
-activityCompose = "1.10.1"
-composeBom = "2025.07.00"
-lifecycleRuntimeCompose = "2.9.3"
+activityCompose = "1.13.0"
+composeBom = "2026.03.01"
+lifecycleRuntimeCompose = "2.10.0"
 composeNavigation = "2.9.3"
 kotlinCompilerExtensionVersion = "1.5.2"
 androidxComposeMaterial3 = "1.3.2"
 
-hilt = "2.57"
-hiltManager = "1.2.0"
+hilt = "2.59.2"
+hiltManager = "1.3.0"
 javax-inject = "1"
 
-okhttp = "5.1.0"
+okhttp = "5.3.2"
 retrofit = "3.0.0"
 retrofitJsonConverter = "1.0.0"
 krossbow = "9.3.0"
@@ -63,7 +62,6 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDatastore" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidxRoomCompiler" }
-androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Tue Feb 25 00:44:04 KST 2025
+#Tue May 05 01:22:36 KST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Work Description ✏️

#### 버전 업그레이드

- agp: `8.11.1` -> `9.0.0`
- Kotlin: `2.1.21` -> `2.3.1`
- compile & target SDK: `35` -> `36`

#### 기타 의존성 버전 업그레이드
- hilt, compose, androidx 라이브러리들...

#### Build-Logic 정리
- AGP 9에서 deprecated된 기능들을 대체: 3eeba28439ee823c82252b651565029b0b8ecf73

## Uncompleted Tasks 😅
- [ ] 36 버전에서 안되는 부분들을 확인해봐야 함 (예: 커스텀 토스트)

## To Reviewers 📢
- Balloon, Navigation3 등 새로운 기능을 도입하려다 보니 프로젝트의 버전을 올리는게 불가피했습니다.. 
   사전에 논의하고 진행했어야 했는데 시기상 절차를 지키기 어려워 PR 먼저 올리는 점 양해바랍니다😓
- 중요한 PR이기 때문에 혹시라도 불편한 점이나 실행이 제대로 되지 않는 부분이 있다면 바로 말씀해주세요!