### PR TITLE
[feat/#383] 믹스패널 트래킹 고도화 및 신규 이벤트 추가

### DIFF
--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ExploreTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ExploreTracker.kt
@@ -61,13 +61,15 @@ class ExploreTracker @Inject constructor(
      * Description : 탐색 화면에서 상품 상세 진입
      * @param postId 게시글 ID
      * @param isForSale 판매글 여부
+     * @param source 유입 경로
      */
-    fun trackViewedProduct(postId: Long, isForSale: Boolean) {
+    fun trackViewedProduct(postId: Long, isForSale: Boolean, source: String) {
         analytics.logEvent(
             MixpanelConstants.VIEWED_PRODUCT,
             mapOf(
                 POST_ID to postId,
                 POST_TYPE to if (isForSale) POST_TYPE_FOR_SALE else POST_TYPE_WANTED,
+                SOURCE to source,
             ),
         )
     }
@@ -95,6 +97,7 @@ class ExploreTracker @Inject constructor(
         private const val SORT = "sort"
         private const val POST_ID = "post_id"
         private const val POST_TYPE = "post_type"
+        private const val SOURCE = "source"
         private const val USER_ROLE = "user_role"
 
         private const val TAB_FOR_SALE = "for_sale"
@@ -110,5 +113,15 @@ class ExploreTracker @Inject constructor(
 
         private const val USER_ROLE_BUYER = "buyer"
         private const val USER_ROLE_SELLER = "seller"
+
+        // Viewed Product Sources
+        const val SOURCE_HOME_FEED = "home_feed"
+        const val SOURCE_EXPLORE_FEED = "explore_feed"
+        const val SOURCE_SEARCH_RESULT = "search_result"
+        const val SOURCE_GENRE_PAGE = "genre_page"
+        const val SOURCE_MY_POST = "my_post"
+        const val SOURCE_MY_PAGE = "my_page"
+        const val SOURCE_CHAT_ROOM = "chat_room"
+        const val SOURCE_WISH_LIST = "wish_list"
     }
 }

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/GlobalTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/GlobalTracker.kt
@@ -1,0 +1,60 @@
+package com.napzak.market.mixpanel
+
+import javax.inject.Inject
+
+/**
+ * Service     : Global
+ * Description : 여러 페이지에서 공통으로 발생하는 액션 트래킹
+ */
+class GlobalTracker @Inject constructor(
+    private val analytics: NapzakAnalytics,
+) {
+
+    /**
+     * Event       : Item Liked
+     * Description : 상품 찜(좋아요) 추가/취소
+     * @param postId 게시글 ID
+     * @param genreName 장르명
+     * @param isForSale 판매글 여부
+     * @param source 찜 액션 발생 화면
+     * @param actionType add / remove
+     */
+    fun trackItemLiked(
+        postId: Long,
+        genreName: String,
+        isForSale: Boolean,
+        source: String,
+        actionType: String,
+    ) {
+        analytics.logEvent(
+            MixpanelConstants.ITEM_LIKED,
+            mapOf(
+                POST_ID to postId,
+                GENRE_NAME to genreName,
+                TAB to if (isForSale) TAB_FOR_SALE else TAB_WANTED,
+                SOURCE to source,
+                ACTION_TYPE to actionType,
+            ),
+        )
+    }
+
+    companion object {
+        private const val POST_ID = "post_id"
+        private const val GENRE_NAME = "genre_name"
+        private const val TAB = "tab"
+        private const val SOURCE = "source"
+        private const val ACTION_TYPE = "action_type"
+
+        private const val TAB_FOR_SALE = "for_sale"
+        private const val TAB_WANTED = "wanted"
+
+        const val SOURCE_HOME_FEED = "home_feed"
+        const val SOURCE_EXPLORE_FEED = "explore_feed"
+        const val SOURCE_SEARCH_RESULT = "search_result"
+        const val SOURCE_GENRE_PAGE = "genre_page"
+        const val SOURCE_ITEM_DETAIL = "item_detail"
+
+        const val ACTION_ADD = "add"
+        const val ACTION_REMOVE = "remove"
+    }
+}

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
@@ -32,12 +32,16 @@ class HomeTracker @Inject constructor(
      * Event       : Clicked custom genre
      * Description : 홈 화면 추천 상품 섹션 클릭 (기존 상수명 유지)
      * @param itemIndex 아이템 위치 순서
+     * @param postId 상품 ID
+     * @param genreName 장르 이름
      */
-    fun trackClickedRecommendProduct(itemIndex: Int) {
+    fun trackClickedRecommendProduct(itemIndex: Int, postId: Long, genreName: String) {
         analytics.logEvent(
             MixpanelConstants.CLICKED_CUSTOM_GENRE,
             mapOf(
                 ITEM_INDEX to itemIndex,
+                POST_ID to postId,
+                GENRES_CATEGORY to genreName,
             ),
         )
     }
@@ -75,6 +79,8 @@ class HomeTracker @Inject constructor(
         private const val BANNER_TYPE = "banner_type"
         private const val BANNER_INDEX = "banner_index"
         private const val ITEM_INDEX = "item_index"
+        private const val POST_ID = "post_id"
+        private const val GENRES_CATEGORY = "genres_category"
         private const val SORT = "sort"
         private const val FROM = "from"
         private const val HOME = "home"

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/HomeTracker.kt
@@ -41,7 +41,7 @@ class HomeTracker @Inject constructor(
             mapOf(
                 ITEM_INDEX to itemIndex,
                 POST_ID to postId,
-                GENRES_CATEGORY to genreName,
+                GENRE_NAME to genreName,
             ),
         )
     }
@@ -80,7 +80,7 @@ class HomeTracker @Inject constructor(
         private const val BANNER_INDEX = "banner_index"
         private const val ITEM_INDEX = "item_index"
         private const val POST_ID = "post_id"
-        private const val GENRES_CATEGORY = "genres_category"
+        private const val GENRE_NAME = "genre_name"
         private const val SORT = "sort"
         private const val FROM = "from"
         private const val HOME = "home"

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MixpanelConstants.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MixpanelConstants.kt
@@ -26,4 +26,5 @@ object MixpanelConstants {
     const val OPENED_REPORT_PRODUCT = "Opened Report Overlay_product"
     const val OPENED_REPORT_MARKET = "Opened Report Overlay_market"
     const val ITEM_STATUS_UPDATED = "Item Status Updated"
+    const val ITEM_LIKED = "Item Liked"
 }

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MixpanelConstants.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/MixpanelConstants.kt
@@ -25,4 +25,5 @@ object MixpanelConstants {
     const val COMPLETED_WITHDRAWAL = "Completed Withdrawal"
     const val OPENED_REPORT_PRODUCT = "Opened Report Overlay_product"
     const val OPENED_REPORT_MARKET = "Opened Report Overlay_market"
+    const val ITEM_STATUS_UPDATED = "Item Status Updated"
 }

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ReportTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/ReportTracker.kt
@@ -25,4 +25,43 @@ class ReportTracker @Inject constructor(
     fun trackOpenedReportMarket() {
         analytics.logEvent(MixpanelConstants.OPENED_REPORT_MARKET)
     }
+
+    /**
+     * Event       : Item Status Updated
+     * Description : 상품 상태(판매/구매 중, 예약 중, 판매/구매 완료) 변경
+     * @param postId 게시글 ID
+     * @param genreName 장르명
+     * @param isForSale 판매글 여부
+     * @param statusLabel 변경된 상태
+     */
+    fun trackItemStatusUpdated(
+        postId: Long,
+        genreName: String,
+        isForSale: Boolean,
+        statusLabel: String,
+    ) {
+        analytics.logEvent(
+            MixpanelConstants.ITEM_STATUS_UPDATED,
+            mapOf(
+                POST_ID to postId,
+                GENRE_NAME to genreName,
+                TAB to if (isForSale) TAB_FOR_SALE else TAB_WANTED,
+                STATUS_LABEL to statusLabel,
+            ),
+        )
+    }
+
+    companion object {
+        private const val POST_ID = "post_id"
+        private const val GENRE_NAME = "genre_name"
+        private const val TAB = "tab"
+        private const val STATUS_LABEL = "status_label"
+
+        private const val TAB_FOR_SALE = "for_sale"
+        private const val TAB_WANTED = "wanted"
+
+        const val STATUS_ON_SALE = "on_sale"
+        const val STATUS_RESERVED = "reserved"
+        const val STATUS_COMPLETED = "completed"
+    }
 }

--- a/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SearchTracker.kt
+++ b/core/mixpanel/src/main/java/com/napzak/market/mixpanel/SearchTracker.kt
@@ -23,16 +23,19 @@ class SearchTracker @Inject constructor(
      * Description : 검색 실행
      * @param searchSource 검색 소스
      * @param keyword 검색어
+     * @param genreName 장르명 (search_source가 genre_page일 때만 값 있음)
      */
     fun trackExecutedSearch(
         searchSource: String,
         keyword: String? = null,
+        genreName: String? = null,
     ) {
         analytics.logEvent(
             MixpanelConstants.EXECUTED_SEARCH,
             mapOf(
                 SEARCH_SOURCE to searchSource,
                 SEARCH_TEXT to keyword,
+                GENRE_NAME to genreName,
             ),
         )
     }
@@ -56,12 +59,13 @@ class SearchTracker @Inject constructor(
     companion object {
         private const val SEARCH_SOURCE = "search_source"
         private const val SEARCH_TEXT = "keyword"
+        private const val GENRE_NAME = "genre_name"
         private const val SUGGESTION_TYPE = "suggestion_type"
         private const val SUGGESTION_INDEX = "suggestion_index"
 
         const val SOURCE_ICON = "icon"
         const val SOURCE_ENTER = "enter"
-        const val SOURCE_SEARCH_BAR = "search_bar"
+        const val SOURCE_SEARCH_BAR = "searchbar"
         const val SOURCE_GENRE_PAGE = "genre_page"
 
         const val SUGGESTION_TYPE_KEYWORD = "keyword"

--- a/core/navigation/src/main/java/com/napzak/market/navigation/keys/ProductScreenKeys.kt
+++ b/core/navigation/src/main/java/com/napzak/market/navigation/keys/ProductScreenKeys.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ProductDetailScreenKey(
     val productId: Long,
+    val source: String? = null,
 ) : ScreenKey

--- a/feature/chat/src/main/java/com/napzak/market/chat/navigation/ChatEntryProvider.kt
+++ b/feature/chat/src/main/java/com/napzak/market/chat/navigation/ChatEntryProvider.kt
@@ -10,6 +10,7 @@ import com.napzak.market.navigation.EntryProviderBuilder
 import com.napzak.market.navigation.keys.ChatListScreenKey
 import com.napzak.market.navigation.keys.ChatRoomScreenKey
 import com.napzak.market.navigation.keys.PhoneVerificationScreenKey
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.navigation.keys.ProductDetailScreenKey
 import com.napzak.market.navigation.keys.ReportScreenKey
 import com.napzak.market.navigation.keys.ScreenKey
@@ -48,7 +49,7 @@ class ChatEntryProvider @Inject constructor(
     }
 
     private fun navigateToProductDetail(productId: Long) {
-        val screenKey = ProductDetailScreenKey(productId = productId)
+        val screenKey = ProductDetailScreenKey(productId = productId, source = ExploreTracker.SOURCE_CHAT_ROOM)
         navigator.navigateTo(screenKey)
     }
 

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
@@ -14,6 +14,7 @@ import com.napzak.market.detail.ProductDetailSideEffect.ShowToast
 import com.napzak.market.detail.type.ProductDetailToastType
 import com.napzak.market.interest.usecase.SetInterestUseCase
 import com.napzak.market.mixpanel.ExploreTracker
+import com.napzak.market.mixpanel.GlobalTracker
 import com.napzak.market.mixpanel.ReportTracker
 import com.napzak.market.navigation.keys.ProductDetailScreenKey
 import com.napzak.market.navigation.util.AssistedNavKeyFactory
@@ -48,6 +49,7 @@ internal class ProductDetailViewModel @AssistedInject constructor(
     private val getPhoneVerificationStatus: GetPhoneVerificationStatusUseCase,
     private val exploreTracker: ExploreTracker,
     private val reportTracker: ReportTracker,
+    private val globalTracker: GlobalTracker,
 ) : ViewModel() {
     @AssistedFactory
     interface Factory : AssistedNavKeyFactory<ProductDetailViewModel, ProductDetailScreenKey>
@@ -115,6 +117,7 @@ internal class ProductDetailViewModel @AssistedInject constructor(
 
     fun updateIsInterested(isInterested: Boolean) = viewModelScope.launch {
         updateInterestAndCount(isInterested)
+        trackItemLiked(isInterested)
         triggerUpdateIsInterestedSideEffect(isInterested)
     }
 
@@ -185,6 +188,21 @@ internal class ProductDetailViewModel @AssistedInject constructor(
 
     fun setShowProductStatusToolTip(value: Boolean) = viewModelScope.launch {
         productDetailRepository.setShowProductStatusTooltip(value)
+    }
+
+    private fun trackItemLiked(isInterested: Boolean) {
+        val currentUiState = productDetail.value
+        if (currentUiState is UiState.Success) {
+            val isForSale = TradeType.fromName(currentUiState.data.tradeType) == TradeType.SELL
+            val actionType = if (isInterested) GlobalTracker.ACTION_ADD else GlobalTracker.ACTION_REMOVE
+            globalTracker.trackItemLiked(
+                postId = currentUiState.data.productId,
+                genreName = currentUiState.data.genreName,
+                isForSale = isForSale,
+                source = GlobalTracker.SOURCE_ITEM_DETAIL,
+                actionType = actionType,
+            )
+        }
     }
 
     private fun trackViewedProduct() {

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
@@ -156,7 +156,10 @@ internal class ProductDetailViewModel @AssistedInject constructor(
                 currentState
             }
         }
-        updatedDetail?.let { triggerUpdateTradeStatusChangeSideEffect(it) }
+        updatedDetail?.let {
+            triggerUpdateTradeStatusChangeSideEffect(it)
+            trackItemStatusUpdated(it, tradeStatus)
+        }
     }
 
     private suspend fun triggerUpdateTradeStatusChangeSideEffect(productDetail: ProductDetail) {
@@ -205,6 +208,22 @@ internal class ProductDetailViewModel @AssistedInject constructor(
                 isForSale = isForSale,
             )
         }
+    }
+
+    private fun trackItemStatusUpdated(productDetail: ProductDetail, tradeStatus: String) {
+        val isForSale = TradeType.fromName(productDetail.tradeType) == TradeType.SELL
+        val statusLabel = when (tradeStatus.uppercase()) {
+            "BEFORE_TRADE" -> ReportTracker.STATUS_ON_SALE
+            "COMPLETED" -> ReportTracker.STATUS_COMPLETED
+            else -> ReportTracker.STATUS_RESERVED
+        }
+
+        reportTracker.trackItemStatusUpdated(
+            postId = productDetail.productId,
+            genreName = productDetail.genreName,
+            isForSale = isForSale,
+            statusLabel = statusLabel,
+        )
     }
 
     internal fun trackReportProduct() = reportTracker.trackOpenedReportProduct()

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailViewModel.kt
@@ -53,6 +53,7 @@ internal class ProductDetailViewModel @AssistedInject constructor(
     interface Factory : AssistedNavKeyFactory<ProductDetailViewModel, ProductDetailScreenKey>
 
     private val productId: Long = navKey.productId
+    private val source: String? = navKey.source
 
     private val _productDetail: MutableStateFlow<UiState<ProductDetail>> =
         MutableStateFlow(UiState.Loading)
@@ -73,12 +74,8 @@ internal class ProductDetailViewModel @AssistedInject constructor(
         )
 
     init {
-        if (productId != null) {
-            getProductDetail(productId)
-            collectAndSetIsInterested(productId)
-        } else {
-            _productDetail.value = UiState.Failure("상품 정보를 불러올 수 없습니다.")
-        }
+        getProductDetail(productId)
+        collectAndSetIsInterested(productId)
     }
 
     fun checkPhoneVerification() = viewModelScope.launch {
@@ -194,6 +191,7 @@ internal class ProductDetailViewModel @AssistedInject constructor(
             exploreTracker.trackViewedProduct(
                 postId = currentUiState.data.productId,
                 isForSale = isForSale,
+                source = source.orEmpty(),
             )
         }
     }
@@ -213,6 +211,5 @@ internal class ProductDetailViewModel @AssistedInject constructor(
 
     companion object {
         private const val DEBOUNCE_DELAY = 500L
-        private const val PRODUCT_ID_KEY = "productId"
     }
 }

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreScreen.kt
@@ -73,6 +73,7 @@ import com.napzak.market.feature.explore.R.string.explore_product
 import com.napzak.market.feature.explore.R.string.explore_search_hint
 import com.napzak.market.feature.explore.R.string.explore_unopened
 import com.napzak.market.genre.model.Genre
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.product.model.Product
 import com.napzak.market.ui_util.noRippleClickable
 
@@ -80,7 +81,7 @@ import com.napzak.market.ui_util.noRippleClickable
 internal fun ExploreRoute(
     onSearchNavigate: () -> Unit,
     onGenreDetailNavigate: (Long) -> Unit,
-    onProductDetailNavigate: (Long) -> Unit,
+    onProductDetailNavigate: (Long, String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ExploreViewModel = hiltViewModel(),
 ) {
@@ -152,9 +153,12 @@ internal fun ExploreRoute(
             viewModel.updateSortOption(newSortOption)
             viewModel.updateBottomSheetVisibility(BottomSheetType.SORT)
         },
-        onProductDetailNavigate = { id, type ->
-            viewModel.trackViewedProduct(id, TradeType.valueOf(type) == TradeType.SELL)
-            onProductDetailNavigate(id)
+        onProductDetailNavigate = { id ->
+            val source =
+                if (viewModel.searchTerm.isNullOrEmpty()) ExploreTracker.SOURCE_EXPLORE_FEED
+                else ExploreTracker.SOURCE_SEARCH_RESULT
+
+            onProductDetailNavigate(id, source)
         },
         onLikeButtonClick = { id, value ->
             viewModel.updateProductIsInterested(productId = id, isInterested = value)
@@ -180,7 +184,7 @@ private fun ExploreScreen(
     onSortOptionClick: (SortType) -> Unit,
     onSortItemClick: (SortType) -> Unit,
     onGenreDetailNavigate: (Long) -> Unit,
-    onProductDetailNavigate: (Long, String) -> Unit,
+    onProductDetailNavigate: (Long) -> Unit,
     onLikeButtonClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -250,7 +254,7 @@ private fun ExploreSuccessScreen(
     onSortOptionClick: (SortType) -> Unit,
     onSortItemClick: (SortType) -> Unit,
     onGenreDetailNavigate: (Long) -> Unit,
-    onProductDetailNavigate: (Long, String) -> Unit,
+    onProductDetailNavigate: (Long) -> Unit,
     onLikeButtonClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -261,7 +265,7 @@ private fun ExploreSuccessScreen(
     var lastSelectedTab by remember { mutableStateOf(selectedTab) }
 
     LaunchedEffect(selectedTab) {
-        if (lastSelectedTab!= selectedTab) {
+        if (lastSelectedTab != selectedTab) {
             lastSelectedTab = selectedTab
             listState.animateScrollToItem(0)
         }
@@ -329,7 +333,7 @@ private fun ExploreSuccessScreen(
             onLikeButtonClick = onLikeButtonClick,
         )
 
-        if (!searchTerm.isNullOrEmpty() && productCount==0) {
+        if (!searchTerm.isNullOrEmpty() && productCount == 0) {
             EmptySearchResultView()
         }
     }
@@ -411,7 +415,7 @@ private fun GenreAndProductList(
     sortType: SortType,
     onGenreButtonClick: (Long) -> Unit,
     onSortOptionClick: () -> Unit,
-    onProductClick: (Long, String) -> Unit,
+    onProductClick: (Long) -> Unit,
     onLikeButtonClick: (Long, Boolean) -> Unit,
 ) {
     LazyColumn(
@@ -510,7 +514,7 @@ private fun GenreAndProductList(
                                 onLikeClick = { onLikeButtonClick(productId, isInterested) },
                                 modifier = Modifier
                                     .weight(1f)
-                                    .noRippleClickable { onProductClick(productId, tradeType) },
+                                    .noRippleClickable { onProductClick(productId) },
                             )
                         }
                     }
@@ -545,7 +549,7 @@ private fun ExploreScreenPreview(modifier: Modifier = Modifier) {
             onSortOptionClick = { },
             onSortItemClick = { },
             onGenreDetailNavigate = { },
-            onProductDetailNavigate = { _, _ -> },
+            onProductDetailNavigate = { },
             onLikeButtonClick = { id, value -> },
             modifier = modifier
         )

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -355,10 +355,6 @@ internal class ExploreViewModel @AssistedInject constructor(
         )
     }
 
-    internal fun trackViewedProduct(productId: Long, isForSale: Boolean) {
-        exploreTracker.trackViewedProduct(productId, isForSale)
-    }
-
     internal fun trackSearchOpened() = searchTracker.trackOpenedSearch()
 
     companion object {

--- a/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/ExploreViewModel.kt
@@ -14,6 +14,7 @@ import com.napzak.market.genre.model.extractGenreIds
 import com.napzak.market.genre.repository.GenreNameRepository
 import com.napzak.market.interest.usecase.SetInterestProductUseCase
 import com.napzak.market.mixpanel.ExploreTracker
+import com.napzak.market.mixpanel.GlobalTracker
 import com.napzak.market.mixpanel.SearchTracker
 import com.napzak.market.navigation.keys.ExploreScreenKey
 import com.napzak.market.navigation.util.AssistedNavKeyFactory
@@ -49,6 +50,7 @@ internal class ExploreViewModel @AssistedInject constructor(
     private val setInterestProductUseCase: SetInterestProductUseCase,
     private val exploreTracker: ExploreTracker,
     private val searchTracker: SearchTracker,
+    private val globalTracker: GlobalTracker,
 ) : ViewModel() {
     @AssistedFactory
     interface Factory : AssistedNavKeyFactory<ExploreViewModel, ExploreScreenKey>
@@ -301,8 +303,10 @@ internal class ExploreViewModel @AssistedInject constructor(
     fun updateProductIsInterested(productId: Long, isInterested: Boolean) = viewModelScope.launch {
         when (val state = uiState.value.loadState) {
             is UiState.Success -> {
+                var trackedProduct: Product? = null
                 val updatedProducts = state.data.productList.map { product ->
                     if (product.productId == productId) {
+                        trackedProduct = product
                         interestDebounceFlow.emit(productId to isInterested)
                         product.copy(isInterested = !product.isInterested)
                     } else {
@@ -312,6 +316,19 @@ internal class ExploreViewModel @AssistedInject constructor(
 
                 val newState = ExploreProducts(state.data.productCount, updatedProducts)
                 updateLoadState(UiState.Success(newState))
+
+                trackedProduct?.let { product ->
+                    val isForSale = TradeType.fromName(product.tradeType) == TradeType.SELL
+                    val source = if (searchTerm.isNullOrEmpty()) GlobalTracker.SOURCE_EXPLORE_FEED else GlobalTracker.SOURCE_SEARCH_RESULT
+                    val actionType = if (isInterested) GlobalTracker.ACTION_REMOVE else GlobalTracker.ACTION_ADD
+                    globalTracker.trackItemLiked(
+                        postId = productId,
+                        genreName = product.genreName,
+                        isForSale = isForSale,
+                        source = source,
+                        actionType = actionType,
+                    )
+                }
 
                 when (isInterested) {
                     true -> _sideEffect.send(ExploreSideEffect.CancelToast)

--- a/feature/explore/src/main/java/com/napzak/market/explore/genredetail/GenreDetailViewModel.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/genredetail/GenreDetailViewModel.kt
@@ -8,7 +8,9 @@ import com.napzak.market.common.type.TradeType
 import com.napzak.market.explore.genredetail.state.GenreDetailProducts
 import com.napzak.market.explore.genredetail.state.GenreDetailUiState
 import com.napzak.market.genre.repository.GenreInfoRepository
+import com.napzak.market.product.model.Product
 import com.napzak.market.interest.repository.InterestProductRepository
+import com.napzak.market.mixpanel.GlobalTracker
 import com.napzak.market.navigation.keys.GenreDetailScreenKey
 import com.napzak.market.navigation.util.AssistedNavKeyFactory
 import com.napzak.market.product.model.ExploreParameters
@@ -29,6 +31,7 @@ class GenreDetailViewModel @AssistedInject constructor(
     private val genreInfoRepository: GenreInfoRepository,
     private val productExploreRepository: ProductExploreRepository,
     private val interestProductRepository: InterestProductRepository,
+    private val globalTracker: GlobalTracker,
 ) : ViewModel() {
     @AssistedFactory
     interface Factory : AssistedNavKeyFactory<GenreDetailViewModel, GenreDetailScreenKey>
@@ -126,8 +129,10 @@ class GenreDetailViewModel @AssistedInject constructor(
         val state = uiState.value.loadState
         when (state) {
             is UiState.Success -> {
+                var trackedProduct: Product? = null
                 val updatedProducts = state.data.productList.map { product ->
                     if (product.productId == productId) {
+                        trackedProduct = product
                         product.copy(isInterested = !product.isInterested)
                     } else {
                         product
@@ -139,6 +144,18 @@ class GenreDetailViewModel @AssistedInject constructor(
                         GenreDetailProducts(state.data.productCount, updatedProducts)
                     )
                 )
+
+                trackedProduct?.let { product ->
+                    val isForSale = TradeType.fromName(product.tradeType) == TradeType.SELL
+                    val actionType = if (isLiked) GlobalTracker.ACTION_REMOVE else GlobalTracker.ACTION_ADD
+                    globalTracker.trackItemLiked(
+                        postId = productId,
+                        genreName = product.genreName,
+                        isForSale = isForSale,
+                        source = GlobalTracker.SOURCE_GENRE_PAGE,
+                        actionType = actionType,
+                    )
+                }
             }
 
             else -> {}

--- a/feature/explore/src/main/java/com/napzak/market/explore/navigation/ExploreEntryProvider.kt
+++ b/feature/explore/src/main/java/com/napzak/market/explore/navigation/ExploreEntryProvider.kt
@@ -5,6 +5,7 @@ import com.napzak.market.explore.ExploreRoute
 import com.napzak.market.explore.ExploreViewModel
 import com.napzak.market.explore.genredetail.GenreDetailRoute
 import com.napzak.market.explore.genredetail.GenreDetailViewModel
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.navigation.AppNavigator
 import com.napzak.market.navigation.EntryProviderBuilder
 import com.napzak.market.navigation.keys.ExploreScreenKey
@@ -33,7 +34,7 @@ class ExploreEntryProvider @Inject constructor(
             GenreDetailRoute(
                 onBackButtonClick = navigator::pop,
                 onHomeNavigate = ::popUpToHome,
-                onProductClick = ::navigateToProductDetail,
+                onProductClick = { productId -> navigateToProductDetail(productId, ExploreTracker.SOURCE_GENRE_PAGE) },
                 viewModel = viewModel,
             )
         }
@@ -47,8 +48,8 @@ class ExploreEntryProvider @Inject constructor(
         navigator.navigateTo(GenreDetailScreenKey(genreId = genreId))
     }
 
-    private fun navigateToProductDetail(productId: Long) {
-        navigator.navigateTo(ProductDetailScreenKey(productId = productId))
+    private fun navigateToProductDetail(productId: Long, source: String? = null) {
+        navigator.navigateTo(ProductDetailScreenKey(productId = productId, source = source))
     }
 
     private fun popUpToHome() {

--- a/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
@@ -260,7 +260,7 @@ private fun HomeSuccessScreen(
                 title = stringResource(home_list_customized_title, nickname),
                 subTitle = stringResource(home_list_customized_sub_title, nickname),
                 onProductClick = { productId, index ->
-                    onTrackRecommendProductClick(index + 1)
+                    onTrackRecommendProductClick(index)
                     onProductClick(productId)
                 },
                 onLikeClick = { productId, isInterest ->

--- a/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeScreen.kt
@@ -158,7 +158,7 @@ private fun HomeScreen(
     onMostInterestedSellNavigate: () -> Unit,
     onMostInterestedBuyNavigate: () -> Unit,
     onTrackBannerClick: (Long, HomeBannerType, Int) -> Unit,
-    onTrackRecommendProductClick: (Int) -> Unit,
+    onTrackRecommendProductClick: (Int, Long, String) -> Unit,
     onTrackPopularProductClick: (HomeProductType) -> Unit,
     onPhoneVerifyClick: () -> Unit,
     onPhoneVerifyDismissClick: () -> Unit,
@@ -212,7 +212,7 @@ private fun HomeSuccessScreen(
     termsLink: String,
     privacyPolicyLink: String,
     onTrackBannerClick: (Long, HomeBannerType, Int) -> Unit,
-    onTrackRecommendProductClick: (Int) -> Unit,
+    onTrackRecommendProductClick: (Int, Long, String) -> Unit,
     onTrackPopularProductClick: (HomeProductType) -> Unit,
     onPhoneVerifyClick: () -> Unit,
     onPhoneVerifyDismissClick: () -> Unit,
@@ -259,12 +259,12 @@ private fun HomeSuccessScreen(
                 products = productRecommends,
                 title = stringResource(home_list_customized_title, nickname),
                 subTitle = stringResource(home_list_customized_sub_title, nickname),
-                onProductClick = { productId, index ->
-                    onTrackRecommendProductClick(index)
+                onProductClick = { productId, index, genreName ->
+                    onTrackRecommendProductClick(index, productId, genreName)
                     onProductClick(productId)
                 },
-                onLikeClick = { productId, isInterest ->
-                    onLikeButtonClick(productId, isInterest, HomeProductType.RECOMMEND)
+                onLikeClick = { id, value ->
+                    onLikeButtonClick(id, value, HomeProductType.RECOMMEND)
                 },
                 modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 32.dp),
             )
@@ -424,7 +424,7 @@ private fun HomeRoutePreview() {
             onMostInterestedSellNavigate = { },
             onMostInterestedBuyNavigate = { },
             onTrackBannerClick = { _, _, _ -> },
-            onTrackRecommendProductClick = {},
+            onTrackRecommendProductClick = { _, _, _ -> },
             onTrackPopularProductClick = {},
             onPhoneVerifyClick = {},
             onPhoneVerifyDismissClick = {},

--- a/feature/home/src/main/java/com/napzak/market/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeViewModel.kt
@@ -272,8 +272,8 @@ internal class HomeViewModel @Inject constructor(
         homeTracker.trackClickedBanner(bannerId, typeString, bannerIndex)
     }
 
-    internal fun trackClickedRecommendProduct(index: Int) {
-        homeTracker.trackClickedRecommendProduct(index)
+    internal fun trackClickedRecommendProduct(index: Int, postId: Long, genreName: String) {
+        homeTracker.trackClickedRecommendProduct(index, postId, genreName)
     }
 
     internal fun trackClickedPopularProduct(productType: HomeProductType) {

--- a/feature/home/src/main/java/com/napzak/market/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/HomeViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.napzak.market.banner.Banner
 import com.napzak.market.common.state.UiState
+import com.napzak.market.common.type.TradeType
 import com.napzak.market.event.PhoneVerificationSessionManager
 import com.napzak.market.home.state.HomeUiState
 import com.napzak.market.home.type.HomeProductType
 import com.napzak.market.interest.usecase.SetInterestProductUseCase
+import com.napzak.market.mixpanel.GlobalTracker
 import com.napzak.market.mixpanel.HomeTracker
 import com.napzak.market.notification.repository.NotificationRepository
 import com.napzak.market.notification.usecase.UpdatePushTokenUseCase
@@ -48,6 +50,7 @@ internal class HomeViewModel @Inject constructor(
     private val getPhoneVerificationStatus: GetPhoneVerificationStatusUseCase,
     private val phoneVerificationSessionManager: PhoneVerificationSessionManager,
     private val homeTracker: HomeTracker,
+    private val globalTracker: GlobalTracker,
 ) : ViewModel() {
     private val nickname = MutableStateFlow("")
     private val _bannerLoadState =
@@ -188,16 +191,30 @@ internal class HomeViewModel @Inject constructor(
             HomeProductType.POPULAR_BUY -> _popularBuyLoadState
         }
 
+        var trackedProduct: Product? = null
         flow.update { currentState ->
             (currentState as UiState.Success<List<Product>>).copy(
                 data = currentState.data.map {
                     if (it.productId == productId) {
+                        trackedProduct = it
                         interestDebounceFlow.emit(productId to isInterested)
                         it.copy(isInterested = !isInterested)
                     } else {
                         it
                     }
                 }
+            )
+        }
+
+        trackedProduct?.let { product ->
+            val isForSale = TradeType.fromName(product.tradeType) == TradeType.SELL
+            val actionType = if (isInterested) GlobalTracker.ACTION_REMOVE else GlobalTracker.ACTION_ADD
+            globalTracker.trackItemLiked(
+                postId = productId,
+                genreName = product.genreName,
+                isForSale = isForSale,
+                source = GlobalTracker.SOURCE_HOME_FEED,
+                actionType = actionType,
             )
         }
 

--- a/feature/home/src/main/java/com/napzak/market/home/component/HorizontalScrollableProducts.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/component/HorizontalScrollableProducts.kt
@@ -34,7 +34,7 @@ internal fun HorizontalScrollableProducts(
     subTitle: String,
     products: ImmutableList<Product>,
     onLikeClick: (Long, Boolean) -> Unit,
-    onProductClick: (Long, Int) -> Unit,
+    onProductClick: (Long, Int, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
 
@@ -69,7 +69,7 @@ internal fun HorizontalScrollableProducts(
 private fun ProductsRow(
     products: ImmutableList<Product>,
     onLikeClick: (Long, Boolean) -> Unit,
-    onItemClick: (Long, Int) -> Unit,
+    onItemClick: (Long, Int, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val configuration = LocalConfiguration.current
@@ -104,7 +104,7 @@ private fun ProductsRow(
                         .width(productWidth.dp)
                         .aspectRatio(PRODUCT_HEIGHT_RATIO)
                         .noRippleClickable {
-                            onItemClick(productId, index)
+                            onItemClick(productId, index, genreName)
                         },
                 )
             }
@@ -122,7 +122,7 @@ private fun HorizontalScrollableProductsPreview() {
                 title = "납자기님을 위한 맞춤 PICK!",
                 subTitle = "납자기님의 취향에 딱 맞는 아이템들을 모아봤어요.",
                 onLikeClick = { _, _ -> },
-                onProductClick = { _, _ -> },
+                onProductClick = { _, _, _ -> },
             )
         }
     }

--- a/feature/home/src/main/java/com/napzak/market/home/navigation/HomeEntryProvider.kt
+++ b/feature/home/src/main/java/com/napzak/market/home/navigation/HomeEntryProvider.kt
@@ -8,6 +8,7 @@ import com.napzak.market.common.type.TradeType.SELL
 import com.napzak.market.event.ChatSessionManager
 import com.napzak.market.event.DeepLinkEvent
 import com.napzak.market.event.DeepLinkEventBus
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.home.HomeRoute
 import com.napzak.market.navigation.AppNavigator
 import com.napzak.market.navigation.EntryProviderBuilder
@@ -48,7 +49,7 @@ class HomeEntryProvider @Inject constructor(
     }
 
     private fun navigateToProductDetail(productId: Long) {
-        navigator.navigateTo(ProductDetailScreenKey(productId))
+        navigator.navigateTo(ProductDetailScreenKey(productId, source = ExploreTracker.SOURCE_HOME_FEED))
     }
 
     private fun navigateToExploreBuy() {

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/mypage/MyPageScreen.kt
@@ -44,7 +44,6 @@ internal fun MyPageRoute(
 
     LaunchedEffect(Unit) {
         viewModel.fetchStoreInfo()
-        viewModel.trackViewedMyPage()
     }
 
     MyPageScreen(

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/mypage/MyPageViewModel.kt
@@ -3,7 +3,6 @@ package com.napzak.market.mypage.mypage
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.napzak.market.common.state.UiState
-import com.napzak.market.mixpanel.MyPageTracker
 import com.napzak.market.mypage.mypage.state.MyPageUiState
 import com.napzak.market.store.repository.StoreRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +16,6 @@ import javax.inject.Inject
 @HiltViewModel
 internal class MyPageViewModel @Inject constructor(
     private val storeRepository: StoreRepository,
-    private val myPageTracker: MyPageTracker,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MyPageUiState())
@@ -47,5 +45,4 @@ internal class MyPageViewModel @Inject constructor(
             }
     }
 
-    internal fun trackViewedMyPage() = myPageTracker.trackViewedMyPage()
 }

--- a/feature/mypage/src/main/java/com/napzak/market/mypage/navigation/MyPageEntryProvider.kt
+++ b/feature/mypage/src/main/java/com/napzak/market/mypage/navigation/MyPageEntryProvider.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation3.runtime.EntryProviderScope
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.mypage.mypage.MyPageRoute
 import com.napzak.market.mypage.setting.SettingsRoute
 import com.napzak.market.mypage.wishlist.WishlistRoute
@@ -76,7 +77,7 @@ class MyPageEntryProvider @Inject constructor(
     }
 
     private fun navigateToProductDetail(productId: Long) {
-        navigator.navigateTo(ProductDetailScreenKey(productId = productId))
+        navigator.navigateTo(ProductDetailScreenKey(productId = productId, source = ExploreTracker.SOURCE_WISH_LIST))
     }
 
     private fun restartApplication(context: Context) {

--- a/feature/registration/src/main/java/com/napzak/market/registration/navigation/RegistrationEntryProvider.kt
+++ b/feature/registration/src/main/java/com/napzak/market/registration/navigation/RegistrationEntryProvider.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import com.napzak.market.genre.model.Genre
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.navigation.AppNavigator
 import com.napzak.market.navigation.EntryProviderBuilder
 import com.napzak.market.navigation.keys.GenreSearchScreenKey
@@ -91,7 +92,7 @@ class RegistrationEntryProvider @Inject constructor(
 
     private fun navigateToProductDetail(productId: Long) {
         navigator.navigateTo(
-            key = ProductDetailScreenKey(productId = productId),
+            key = ProductDetailScreenKey(productId = productId, source = ExploreTracker.SOURCE_MY_POST),
             popUpTo = navigator.currentScreen,
             inclusive = true,
             singleTop = true,

--- a/feature/search/src/main/java/com/napzak/market/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/napzak/market/search/SearchScreen.kt
@@ -86,7 +86,7 @@ internal fun SearchRoute(
         onBackButtonClick = onBackButtonClick,
         onTextChange = viewModel::updateSearchTerm,
         onSearchClick = { onSearchResultNavigate(searchText) },
-        onTrackSearchClick = { viewModel.trackExecutedSearch(it) },
+        onTrackSearchClick = { source, genreName -> viewModel.trackExecutedSearch(source, genreName) },
         onRecommendedSearchWordClick = onSearchResultNavigate,
         onTrackSearchWordClick = { viewModel.trackClickedSearchWord(it) },
         onRecommendedGenreClick = onGenreDetailNavigate,
@@ -103,7 +103,7 @@ private fun SearchScreen(
     onBackButtonClick: () -> Unit,
     onTextChange: (String) -> Unit,
     onSearchClick: () -> Unit,
-    onTrackSearchClick: (String) -> Unit,
+    onTrackSearchClick: (String, String?) -> Unit,
     onRecommendedSearchWordClick: (String) -> Unit,
     onTrackSearchWordClick: (Int) -> Unit,
     onRecommendedGenreClick: (Long) -> Unit,
@@ -151,7 +151,7 @@ private fun SearchSuccessScreen(
     onBackButtonClick: () -> Unit,
     onTextChange: (String) -> Unit,
     onSearchClick: () -> Unit,
-    onTrackSearchClick: (String) -> Unit,
+    onTrackSearchClick: (String, String?) -> Unit,
     onRecommendedSearchWordClick: (String) -> Unit,
     onTrackSearchWordClick: (Int) -> Unit,
     onRecommendedGenreClick: (Long) -> Unit,
@@ -200,8 +200,8 @@ private fun SearchSuccessScreen(
                 onResetClick = { onTextChange(EMPTY_TEXT) },
                 onSearchClick = onSearchClick,
                 focusRequester = focusRequester,
-                onTrackIconClick = { onTrackSearchClick(SearchTracker.SOURCE_ICON) },
-                onTrackKeyboardClick = { onTrackSearchClick(SearchTracker.SOURCE_ENTER) },
+                onTrackIconClick = { onTrackSearchClick(SearchTracker.SOURCE_ICON, null) },
+                onTrackKeyboardClick = { onTrackSearchClick(SearchTracker.SOURCE_ENTER, null) },
             )
         }
 
@@ -240,7 +240,7 @@ private fun SearchSuccessScreen(
                         BasicResultNavigationButton(
                             searchText = searchText,
                             onButtonClick = {
-                                onTrackSearchClick(SearchTracker.SOURCE_SEARCH_BAR)
+                                onTrackSearchClick(SearchTracker.SOURCE_SEARCH_BAR, null)
                                 onSearchClick()
                             },
                         )
@@ -258,7 +258,7 @@ private fun SearchSuccessScreen(
                     GenreNavigationButton(
                         genreName = genreItem.genreName,
                         onBlockClick = {
-                            onTrackSearchClick(SearchTracker.SOURCE_GENRE_PAGE)
+                            onTrackSearchClick(SearchTracker.SOURCE_GENRE_PAGE, genreItem.genreName)
                             onRecommendedGenreClick(genreItem.genreId)
                         },
                         modifier = Modifier.background(color = NapzakMarketTheme.colors.white),
@@ -414,7 +414,7 @@ private fun SearchScreenPreview(modifier: Modifier = Modifier) {
             onBackButtonClick = { },
             onTextChange = { searchText = it },
             onSearchClick = { },
-            onTrackSearchClick = { },
+            onTrackSearchClick = { _, _ -> },
             onRecommendedSearchWordClick = { },
             onTrackSearchWordClick = { },
             onRecommendedGenreClick = { },

--- a/feature/search/src/main/java/com/napzak/market/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/napzak/market/search/SearchScreen.kt
@@ -344,7 +344,7 @@ private fun SuggestedSearchTextSection(
             recommendedSearchWords.forEachIndexed { index, searchWord ->
                 SuggestedKeywordChip(
                     keyword = searchWord.searchWord,
-                    onKeywordChipClick = { onTextChipClick(searchWord.searchWord, index + 1) },
+                    onKeywordChipClick = { onTextChipClick(searchWord.searchWord, index) },
                 )
             }
         }
@@ -380,7 +380,7 @@ private fun SuggestedGenreSection(
                     SuggestedGenreCard(
                         genreName = genre.genreName,
                         imgUrl = genre.genrePhoto.toString(),
-                        onCardClick = { onGenreCardClick(genre.genreId, row * 3 + col + 1) },
+                        onCardClick = { onGenreCardClick(genre.genreId, row * 3 + col) },
                         modifier = Modifier.width(100.dp),
                     )
                 }

--- a/feature/search/src/main/java/com/napzak/market/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/napzak/market/search/SearchViewModel.kt
@@ -75,10 +75,11 @@ class SearchViewModel @Inject constructor(
             )
         }
 
-    internal fun trackExecutedSearch(source: String) {
+    internal fun trackExecutedSearch(source: String, genreName: String? = null) {
         searchTracker.trackExecutedSearch(
             searchSource = source,
             keyword = searchTerm.value,
+            genreName = genreName,
         )
     }
 

--- a/feature/store/src/main/java/com/napzak/market/store/navigation/StoreEntryProvider.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/navigation/StoreEntryProvider.kt
@@ -2,6 +2,7 @@ package com.napzak.market.store.navigation
 
 import androidx.navigation3.runtime.EntryProviderScope
 import com.napzak.market.common.type.ReportType
+import com.napzak.market.mixpanel.ExploreTracker
 import com.napzak.market.navigation.AppNavigator
 import com.napzak.market.navigation.EntryProviderBuilder
 import com.napzak.market.navigation.keys.EditStoreScreenKey
@@ -41,7 +42,7 @@ class StoreEntryProvider @Inject constructor(
     }
 
     private fun navigateToProductDetail(productId: Long) {
-        navigator.navigateTo(ProductDetailScreenKey(productId = productId))
+        navigator.navigateTo(ProductDetailScreenKey(productId = productId, source = ExploreTracker.SOURCE_MY_PAGE))
     }
 
     private fun navigateToStoreReport(userId: Long) {

--- a/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
+++ b/feature/store/src/main/java/com/napzak/market/store/store/StoreViewModel.kt
@@ -10,6 +10,7 @@ import com.napzak.market.genre.model.Genre
 import com.napzak.market.genre.model.extractGenreIds
 import com.napzak.market.genre.repository.GenreNameRepository
 import com.napzak.market.interest.usecase.SetInterestProductUseCase
+import com.napzak.market.mixpanel.MyPageTracker
 import com.napzak.market.navigation.keys.StoreScreenKey
 import com.napzak.market.navigation.util.AssistedNavKeyFactory
 import com.napzak.market.product.model.Product
@@ -49,6 +50,7 @@ class StoreViewModel @AssistedInject constructor(
     private val getProductStoreUseCase: GetStoreProductsUseCase,
     private val genreNameRepository: GenreNameRepository,
     private val setInterestProductUseCase: SetInterestProductUseCase,
+    private val myPageTracker: MyPageTracker,
 ) : ViewModel() {
     @AssistedFactory
     interface Factory : AssistedNavKeyFactory<StoreViewModel, StoreScreenKey>
@@ -124,7 +126,10 @@ class StoreViewModel @AssistedInject constructor(
 
     fun updateStoreDetail() = viewModelScope.launch {
         storeRepository.fetchStoreDetail(storeId)
-            .onSuccess { _storeDetailState.value = UiState.Success(it) }
+            .onSuccess {
+                _storeDetailState.value = UiState.Success(it)
+                if (it.isOwner) myPageTracker.trackViewedMyPage()
+            }
             .onFailure { _storeDetailState.value = UiState.Failure(it.message.toString()) }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #383

## Work Description ✏️
- 믹스패널 데이터 인덱싱 로직 수정
- `Viewed Product` 이벤트에 `source` 속성 추가 — 진입 경로(Home, Explore, Store 등)를 Navigation 레이어에서 전달하도록 수정
- 홈 추천 상품 트래킹 고도화 — `Clicked Recommend Product` 이벤트에 index, post_id, genre_name 속성 추가
- `Executed Search` 이벤트에 `genre_name` 속성 추가 (search_source가 genre_page일 때만 값 포함)
- `Item Status Updated` 이벤트 트래킹 추가 (상품 상태 변경 시 post_id, genre_name, tab, status_label 로깅)
- `Viewed MyPage` 트래킹 위치 수정 — MyPageScreen이 아닌 StoreScreen에서 `isOwner`일 때만 로깅되도록 변경
- `Item Liked` 이벤트 트래킹 추가 — Home, Explore, GenreDetail, ProductDetail 4개 화면에서 찜 추가/취소 시 post_id, genre_name, tab, source, action_type 로깅

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Viewed Search Result - 보류

## To Reviewers 📢
- `Viewed MyPage`가 기존에 MyPageScreen 진입 시 로깅되고 있었는데, 실제 "내 마켓을 봤다"는 시점은 StoreScreen에서 `isOwner == true`일 때이므로 해당 위치로 이동했습니다.
- `Item Liked`는 `GlobalTracker`를 새로 추가하여 여러 화면에서 공통으로 사용할 수 있도록 했습니다.
- `Viewed Search Result`는 현재 구조상 팔아요/구해요 탭 전환 및 필터 변경 시마다 중복 발화되는 문제가 있어 일단 보류하기로 했습니다~