### PR TITLE
[FEAT/#401] 번호 인증상태 갱신 시점을 수정

### DIFF
--- a/data/store/src/main/java/com/napzak/market/store/datasource/StoreDataSource.kt
+++ b/data/store/src/main/java/com/napzak/market/store/datasource/StoreDataSource.kt
@@ -79,6 +79,10 @@ class StoreDataSource @Inject constructor(
         return storeService.getPhoneVerificationStatus().data
     }
 
+    suspend fun patchPhoneVerificationStatus(): EmptyDataResponse {
+        return storeService.patchPhoneVerificationStatus()
+    }
+
     suspend fun postPhoneVerificationCode(request: PhoneCodeRequest): PhoneCodeResponse {
         return storeService.postPhoneVerificationCode(request).data
     }

--- a/data/store/src/main/java/com/napzak/market/store/dto/response/CodeVerificationResponse.kt
+++ b/data/store/src/main/java/com/napzak/market/store/dto/response/CodeVerificationResponse.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CodeVerificationResponse(
-    @SerialName("isPhoneVerified")
-    val isPhoneVerified: Boolean,
+    @SerialName("isCodeMatched")
+    val isCodeMatched: Boolean,
     @SerialName("remainingRequestCount")
     val remainingRequestCount: Int,
 )

--- a/data/store/src/main/java/com/napzak/market/store/mapper/StoreMapper.kt
+++ b/data/store/src/main/java/com/napzak/market/store/mapper/StoreMapper.kt
@@ -72,7 +72,7 @@ fun PhoneCodeResponse.toDomain(): Int {
 
 fun CodeVerificationResponse.toDomain(): PhoneCodeVerificationResult {
     return PhoneCodeVerificationResult(
-        isPhoneVerified = isPhoneVerified,
+        isCodeVerified = isCodeMatched,
         remainingRequestCount = remainingRequestCount,
     )
 }

--- a/data/store/src/main/java/com/napzak/market/store/repositoryimpl/StoreRepositoryImpl.kt
+++ b/data/store/src/main/java/com/napzak/market/store/repositoryimpl/StoreRepositoryImpl.kt
@@ -98,4 +98,8 @@ class StoreRepositoryImpl @Inject constructor(
             request = CodeVerificationRequest(phoneNumber, code)
         ).toDomain()
     }
+
+    override suspend fun patchPhoneVerificationStatus(): Result<Unit> = runCatching {
+        storeDataSource.patchPhoneVerificationStatus()
+    }
 }

--- a/data/store/src/main/java/com/napzak/market/store/service/StoreService.kt
+++ b/data/store/src/main/java/com/napzak/market/store/service/StoreService.kt
@@ -19,6 +19,7 @@ import com.napzak.market.store.dto.response.TermsResponse
 import com.napzak.market.store.dto.response.WithdrawResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -84,6 +85,9 @@ interface StoreService {
 
     @GET("stores/phone-verification-status")
     suspend fun getPhoneVerificationStatus(): BaseResponse<PhoneVerificationStatusResponse>
+
+    @PATCH("stores/phone-verifications")
+    suspend fun patchPhoneVerificationStatus(): EmptyDataResponse
 
     @POST("stores/phone-verifications/send")
     suspend fun postPhoneVerificationCode(

--- a/domain/store/src/main/java/com/napzak/market/store/model/PhoneCodeVerificationResult.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/model/PhoneCodeVerificationResult.kt
@@ -1,6 +1,6 @@
 package com.napzak.market.store.model
 
 data class PhoneCodeVerificationResult(
-    val isPhoneVerified: Boolean,
+    val isCodeVerified: Boolean,
     val remainingRequestCount: Int,
 )

--- a/domain/store/src/main/java/com/napzak/market/store/repository/StoreRepository.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/repository/StoreRepository.kt
@@ -40,4 +40,6 @@ interface StoreRepository {
     suspend fun postPhoneVerificationCode(phoneNumber: String): Result<Int>
 
     suspend fun checkPhoneVerificationCode(phoneNumber: String, code: String): Result<PhoneCodeVerificationResult>
+
+    suspend fun patchPhoneVerificationStatus(): Result<Unit>
 }

--- a/domain/store/src/main/java/com/napzak/market/store/usecase/UpdateUserProfileUseCase.kt
+++ b/domain/store/src/main/java/com/napzak/market/store/usecase/UpdateUserProfileUseCase.kt
@@ -3,12 +3,13 @@ package com.napzak.market.store.usecase
 import com.napzak.market.store.repository.StoreRepository
 import javax.inject.Inject
 
-class SetNicknameUseCase @Inject constructor(
+class UpdateUserProfileUseCase @Inject constructor(
     private val storeRepository: StoreRepository,
 ) {
     suspend operator fun invoke(nickname: String): Result<Unit> {
         return runCatching {
-            storeRepository.postRegisterNickname(nickname)
+            storeRepository.postRegisterNickname(nickname).getOrThrow()
+            storeRepository.patchPhoneVerificationStatus().getOrThrow()
         }
     }
 }

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/nickname/NicknameViewModel.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/nickname/NicknameViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.napzak.market.onboarding.nickname.model.NicknameUiState
 import com.napzak.market.store.usecase.CheckNicknameDuplicationUseCase
-import com.napzak.market.store.usecase.SetNicknameUseCase
+import com.napzak.market.store.usecase.UpdateUserProfileUseCase
 import com.napzak.market.store.usecase.ValidateNicknameUseCase
 import com.napzak.market.ui_util.getHttpExceptionMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NicknameViewModel @Inject constructor(
     private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
-    private val setNicknameUseCase: SetNicknameUseCase,
+    private val updateUserProfile: UpdateUserProfileUseCase,
     private val validateNicknameUseCase: ValidateNicknameUseCase,
 ) : ViewModel() {
 
@@ -73,7 +73,7 @@ class NicknameViewModel @Inject constructor(
         if (nickname.isBlank()) return
 
         viewModelScope.launch {
-            val result = setNicknameUseCase(nickname)
+            val result = updateUserProfile(nickname)
             result
                 .onSuccess { onSuccess() }
                 .onFailure { onError() }

--- a/feature/onboarding/src/main/java/com/napzak/market/onboarding/phoneVerification/PhoneVerificationViewModel.kt
+++ b/feature/onboarding/src/main/java/com/napzak/market/onboarding/phoneVerification/PhoneVerificationViewModel.kt
@@ -135,7 +135,7 @@ class PhoneVerificationViewModel @Inject constructor(
 
         checkCodeVerified(phoneNumber = current.checkingPhone, code = current.code)
             .onSuccess { response ->
-                if (response.isPhoneVerified) {
+                if (response.isCodeVerified) {
                     stopTimer()
                     _uiState.update {
                         it.copy(


### PR DESCRIPTION
## Related issue 🛠
- closed #401
- branched from #398 

## Work Description ✏️
- 인증번호를 비교하는 api의 필드를 수정 : `isPhoneVerified` -> `isCodeMatched`
- 인증상태를 갱신하는 api를 추가
- 닉네임 화면에서 닉네임을 확정하고 `다음` 버튼을 누를 때 인증상태를 갱신하도록 설정
- 닉네임을 서버로 전송하는 유즈케이스의 이름을 유저 데이터를 전송한다는 의미의 "UpdateUserProfile"로 수정

## To Reviewers 📢
- 슬랙에서 논의된 "뒤로 가기 제어"는 필요하지 않아서 제외했습니다. 참고로 제외하는 것도 슬랙에서 논의됐습니다.
- 생각보다 코드 수정이 적어서 뭔가 놓친게 있는건가 싶네요.. 리뷰할 때 자체 qa도 해주시면 감사하겠습니다.
