### PR TITLE
[CHORE/#404] 서명 키스토어 설정

### DIFF
--- a/.github/workflows/android_develop.yml
+++ b/.github/workflows/android_develop.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           mkdir ./app/signing
           echo '${{ secrets.DEBUG_KEYSTORE_JKS }}' | base64 -d > ./app/signing/napzak-debug.jks
-          echo '${{ secrets.KEYSTORE_JKS }}' | base64 -d > ./app/signing/napzak-keystore.jks
           echo '${{ secrets.KEYSTORE_PROPERTIES }}' > ./app/signing/keystore.properties
 
       - name: Build with Gradle

--- a/.github/workflows/android_develop.yml
+++ b/.github/workflows/android_develop.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Create keystore.properties
         run: |
           mkdir ./app/signing
+          echo '${{ secrets.DEBUG_KEYSTORE_JKS }}' | base64 -d > ./app/signing/napzak-debug.jks
           echo '${{ secrets.KEYSTORE_JKS }}' | base64 -d > ./app/signing/napzak-keystore.jks
           echo '${{ secrets.KEYSTORE_PROPERTIES }}' > ./app/signing/keystore.properties
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,5 +1,4 @@
 /build
-/signing/napzak_keystore.jks
 /signing/keystore.properties
 /src/release/google-services.json
 /src/debug/google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ val keystoreProperties = Properties().apply {
     if (f.exists()) f.inputStream().use { load(it) }
 }
 
+
 val kakaoNativeKey: String =
     providers.gradleProperty("KAKAO_APP_KEY").orNull
         ?: System.getenv("KAKAO_APP_KEY")
@@ -26,11 +27,17 @@ android {
     namespace = "com.napzak.market"
 
     signingConfigs {
+        getByName("debug") {
+            storeFile = rootProject.file(keystoreProperties.getProperty("debug.keystorePath"))
+            keyAlias = keystoreProperties.getProperty("debug.keyAlias")
+            keyPassword = keystoreProperties.getProperty("debug.keyPassword")
+            storePassword = keystoreProperties.getProperty("debug.storePassword")
+        }
         create("release") {
-            storeFile = rootProject.file(keystoreProperties.getProperty("keystorePath"))
-            keyAlias = keystoreProperties.getProperty("keyAlias")
-            keyPassword = keystoreProperties.getProperty("keyPassword")
-            storePassword = keystoreProperties.getProperty("storePassword")
+            storeFile = rootProject.file(keystoreProperties.getProperty("release.keystorePath"))
+            keyAlias = keystoreProperties.getProperty("release.keyAlias")
+            keyPassword = keystoreProperties.getProperty("release.keyPassword")
+            storePassword = keystoreProperties.getProperty("release.storePassword")
         }
     }
 
@@ -41,6 +48,7 @@ android {
 
     buildTypes {
         debug {
+            signingConfig = signingConfigs.getByName("debug")
             isMinifyEnabled = false
             isDebuggable = true
             applicationIdSuffix = ".debug"


### PR DESCRIPTION
## Related issue 🛠
- closed #404

## Work Description ✏️
- debug / release 키스토어를 분리하고 `keystore.properties`에서 프로퍼티를 로드하도록 `build.gradle.kts` 수정
- debug `signingConfig` 추가 및 debug buildType에 연결
- release 키 프로퍼티명 통일 (`keystorePath` → `release.keystorePath` 등)
- `.gitignore`에서 기존 `.jks` 제외 규칙 제거 → `keystore.properties` 제외로 정리

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
없음

## To Reviewers 📢
- `keystore.properties`는 슬랙에 전달드린걸로 대체하시면 됩니다~