### PR TITLE
[CHORE/#419] targetSdk를 36으로 업그레이드

### DIFF
--- a/build-logic/src/main/java/com/napzak/market/buildlogic/convention/ApplicationPlugin.kt
+++ b/build-logic/src/main/java/com/napzak/market/buildlogic/convention/ApplicationPlugin.kt
@@ -34,6 +34,7 @@ class ApplicationPlugin : Plugin<Project> {
                     applicationId = "com.napzak.market"
                     versionCode = libs.version("versionCode").toInt()
                     versionName = libs.version("versionName")
+                    targetSdk = libs.version("targetSdk").toInt()
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.0"
 minSdk = "28"
-targetSdk = "35"
+targetSdk = "36"
 compileSdk = "36"
 jvmTarget = "17"
 versionCode = "20101"


### PR DESCRIPTION
## Related issue 🛠
- closed #419 

## Work Description ✏️
- targetSDK의 버전을 36으로 수정
- targetSdk을 app 모듈 빌드 파일에 적용