### PR TITLE
[FIX/#418] 이미지 오버레이가 topbar/bottombar에 가려지는 오류 수정

### DIFF
--- a/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
+++ b/core/designsystem/src/main/java/com/napzak/market/designsystem/component/image/ZoomableImageScreen.kt
@@ -1,5 +1,6 @@
 package com.napzak.market.designsystem.component.image
 
+import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -13,6 +14,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
@@ -30,10 +32,12 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.core.view.WindowInsetsControllerCompat
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.napzak.market.designsystem.R.drawable.ic_gray_arrow_left
@@ -51,6 +55,20 @@ fun ZoomableImageScreen(
 ) {
     val pagerState = rememberPagerState(initialPage = initialPage) { imageUrls.size }
     var layoutSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val view = LocalView.current
+    DisposableEffect(Unit) {
+        val window = (view.context as? Activity)?.window
+        val controller = window?.let { WindowInsetsControllerCompat(it, view) }
+
+        controller?.isAppearanceLightStatusBars = false
+        controller?.isAppearanceLightNavigationBars = false
+
+        onDispose {
+            controller?.isAppearanceLightStatusBars = true
+            controller?.isAppearanceLightNavigationBars = true
+        }
+    }
 
     Box(
         modifier = modifier

--- a/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
+++ b/feature/detail/src/main/java/com/napzak/market/detail/ProductDetailScreen.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.WindowInsets
@@ -240,87 +241,107 @@ private fun ProductDetailScreen(
 ) {
     var sheetVisibility by remember { mutableStateOf(false) }
     var deleteDialogVisibility by remember { mutableStateOf(false) }
+    var selectedImageIndex: Int? by remember { mutableStateOf(null) }
 
-    Scaffold(
-        topBar = {
-            DetailTopBar(
-                showToolTip = showProductStatusToolTip
-                        && (uiState is UiState.Success && uiState.data.isOwnedByCurrentUser),
-                onBackClick = onBackButtonClick,
-                onShareClick = onShareClick,
-                onOptionClick = { sheetVisibility = true },
-                onTooltipDismiss = { onTooltipDismiss(false) },
-            )
-        },
-        bottomBar = {
-            if (uiState is UiState.Success && !uiState.data.isOwnedByCurrentUser) {
-                val productId = uiState.data.productId
-                val isInterested = uiState.data.isInterested
-                ProductDetailBottomBar(
-                    isLiked = isInterested,
-                    onChatButtonClick = { onChatButtonClick(productId) },
-                    onLikeButtonClick = { onLikeButtonClick(!isInterested) },
+    BackHandler(selectedImageIndex != null) {
+        selectedImageIndex = null
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                DetailTopBar(
+                    showToolTip = showProductStatusToolTip
+                            && (uiState is UiState.Success && uiState.data.isOwnedByCurrentUser),
+                    onBackClick = onBackButtonClick,
+                    onShareClick = onShareClick,
+                    onOptionClick = { sheetVisibility = true },
+                    onTooltipDismiss = { onTooltipDismiss(false) },
                 )
-            }
-        },
-        containerColor = NapzakMarketTheme.colors.white,
-        modifier = modifier,
-    ) { innerPadding ->
-        when (uiState) {
-            is UiState.Success -> {
-                val productDetail = uiState.data
-                val productPhotos = uiState.data.productPhotos
-                val storeInfo = uiState.data.storeInfo
-
-                val tradeType = TradeType.fromName(productDetail.tradeType)
-                val tradeStatus = TradeStatusType.get(productDetail.tradeStatus, tradeType)
-
-                SuccessScreen(
-                    productDetail = productDetail,
-                    productPhotos = productPhotos.toImmutableList(),
-                    marketInfo = storeInfo,
-                    tradeType = tradeType,
-                    tradeStatus = tradeStatus,
-                    onMarketClick = { onMarketClick(storeInfo.userId) },
-                    modifier = Modifier.padding(innerPadding),
-                )
-
-                ProductDetailBottomSheet(
-                    sheetVisibility = sheetVisibility,
-                    productDetail = productDetail,
-                    tradeType = tradeType,
-                    tradeStatus = tradeStatus,
-                    onModifyProductClick = {
-                        onModifyProductClick(
-                            productDetail.productId,
-                            tradeType
-                        )
-                    },
-                    onDeleteProductClick = { deleteDialogVisibility = true },
-                    onReportProductClick = { onReportProductClick(productDetail.productId) },
-                    onTradeStatusChange = { newStatus ->
-                        onTradeStatusChange(productDetail.productId, newStatus.typeName)
-                    },
-                    onBottomSheetDismiss = { sheetVisibility = false },
-                )
-
-                ProductDetailDeleteDialog(
-                    enabled = deleteDialogVisibility,
-                    onConfirmClick = { onDeleteProductClick(productDetail.productId) },
-                    onDismissClick = { deleteDialogVisibility = false },
-                )
-
-                if (isPhoneVerifyModalVisible) {
-                    NapzakPhoneVerifyModal(
-                        onDismissClick = onDismissClick,
-                        onPhoneVerifyClick = onPhoneVerifyClick,
-                        modifier = modifier,
+            },
+            bottomBar = {
+                if (uiState is UiState.Success && !uiState.data.isOwnedByCurrentUser) {
+                    val productId = uiState.data.productId
+                    val isInterested = uiState.data.isInterested
+                    ProductDetailBottomBar(
+                        isLiked = isInterested,
+                        onChatButtonClick = { onChatButtonClick(productId) },
+                        onLikeButtonClick = { onLikeButtonClick(!isInterested) },
                     )
                 }
-            }
+            },
+            containerColor = NapzakMarketTheme.colors.white,
+            modifier = modifier,
+        ) { innerPadding ->
+            when (uiState) {
+                is UiState.Success -> {
+                    val productDetail = uiState.data
+                    val productPhotos = uiState.data.productPhotos
+                    val storeInfo = uiState.data.storeInfo
 
-            is UiState.Loading -> NapzakLoadingOverlay()
-            else -> {} // TODO: Empty, Failure 처리
+                    val tradeType = TradeType.fromName(productDetail.tradeType)
+                    val tradeStatus = TradeStatusType.get(productDetail.tradeStatus, tradeType)
+
+                    SuccessScreen(
+                        productDetail = productDetail,
+                        productPhotos = productPhotos.toImmutableList(),
+                        marketInfo = storeInfo,
+                        tradeType = tradeType,
+                        tradeStatus = tradeStatus,
+                        onMarketClick = { onMarketClick(storeInfo.userId) },
+                        onImageClick = { selectedImageIndex = it },
+                        modifier = Modifier.padding(innerPadding),
+                    )
+
+                    ProductDetailBottomSheet(
+                        sheetVisibility = sheetVisibility,
+                        productDetail = productDetail,
+                        tradeType = tradeType,
+                        tradeStatus = tradeStatus,
+                        onModifyProductClick = {
+                            onModifyProductClick(
+                                productDetail.productId,
+                                tradeType
+                            )
+                        },
+                        onDeleteProductClick = { deleteDialogVisibility = true },
+                        onReportProductClick = { onReportProductClick(productDetail.productId) },
+                        onTradeStatusChange = { newStatus ->
+                            onTradeStatusChange(productDetail.productId, newStatus.typeName)
+                        },
+                        onBottomSheetDismiss = { sheetVisibility = false },
+                    )
+
+                    ProductDetailDeleteDialog(
+                        enabled = deleteDialogVisibility,
+                        onConfirmClick = { onDeleteProductClick(productDetail.productId) },
+                        onDismissClick = { deleteDialogVisibility = false },
+                    )
+
+                    if (isPhoneVerifyModalVisible) {
+                        NapzakPhoneVerifyModal(
+                            onDismissClick = onDismissClick,
+                            onPhoneVerifyClick = onPhoneVerifyClick,
+                            modifier = modifier,
+                        )
+                    }
+                }
+
+                is UiState.Loading -> NapzakLoadingOverlay()
+                else -> {} // TODO: Empty, Failure 처리
+            }
+        }
+
+        if (uiState is UiState.Success) {
+            selectedImageIndex?.let {
+                ZoomableImageScreen(
+                    imageUrls = uiState.data.productPhotos.map { photo -> photo.photoUrl }
+                        .toImmutableList(),
+                    initialPage = it,
+                    contentDescription = uiState.data.productName,
+                    onBackClick = { selectedImageIndex = null },
+                )
+            }
         }
     }
 }
@@ -333,24 +354,11 @@ private fun SuccessScreen(
     tradeStatus: TradeStatusType,
     marketInfo: StoreInfo,
     onMarketClick: () -> Unit,
+    onImageClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedImageIndex: Int? by remember { mutableStateOf(null) }
     val imageUrls = remember(productPhotos) {
         productPhotos.map { it.photoUrl }.toImmutableList()
-    }
-
-    BackHandler(selectedImageIndex != null) {
-        selectedImageIndex = null
-    }
-
-    selectedImageIndex?.let {
-        ZoomableImageScreen(
-            imageUrls = imageUrls,
-            initialPage = it,
-            contentDescription = productDetail.productName,
-            onBackClick = { selectedImageIndex = null },
-        )
     }
 
     LazyColumn(modifier = modifier) {
@@ -359,7 +367,7 @@ private fun SuccessScreen(
                 imageUrls = imageUrls,
                 contentDescription = productDetail.productName,
                 tradeStatusType = tradeStatus,
-                onClick = { selectedImageIndex = it },
+                onClick = onImageClick,
             )
 
             with(productDetail) {
@@ -563,6 +571,7 @@ private fun ProductDetailScreenPreview() {
             productPhotos = mockProductDetail.productPhotos.toImmutableList(),
             marketInfo = mockProductDetail.storeInfo,
             onMarketClick = {},
+            onImageClick = {},
             modifier = Modifier,
             tradeType = tradeType,
             tradeStatus = tradeStatus,


### PR DESCRIPTION
## Related issue 🛠
- closed #418 

## Work Description ✏️
- 이미지 오버레이가 topbar/bottombar에 가려지지 않도록 배치를 수정
- 이미지 오버레이가 화면에 표시됐을 때 시스템바들의 색상이 투명해지도록 수정

## Screenshot 📸

| before | after |
|:--:|:--:|
| <img width="300" alt="KakaoTalk_Photo_2026-08-21-00-06-08 001" src="https://github.com/user-attachments/assets/f5bc32e8-a712-4a67-8f76-d454477c521b" /> | <img width="300" alt="KakaoTalk_Photo_2026-08-21-00-06-09 002" src="https://github.com/user-attachments/assets/6342a54c-4daf-4168-90b5-d48136016075" /> |